### PR TITLE
BUG: fix null pointer crash in view to world with no active camera

### DIFF
--- a/Rendering/Core/vtkRenderer.cxx
+++ b/Rendering/Core/vtkRenderer.cxx
@@ -1247,6 +1247,13 @@ void vtkRenderer::ViewToWorld(double &x, double &y, double &z)
   double mat[16];
   double result[4];
 
+  if (this->ActiveCamera == NULL)
+    {
+    vtkErrorMacro("ViewToWorld: no active camera, cannot compute view to world, returning 0,0,0");
+    x = y = z = 0.0;
+    return;
+    }
+
   // get the perspective transformation from the active camera
   vtkMatrix4x4 *matrix = this->ActiveCamera->
                 GetCompositeProjectionTransformMatrix(


### PR DESCRIPTION
When Slicer layouts change, the slice node can be set and trigger an
update of widget positions before the renderer is fully set up. This
change avoids a null pointer crash caused by the renderer not checking
before dereferencing the ActiveCamera pointer. Match the error message
printed by the WorldToView method at line 1303, return 0,0,0.

Slicer Issue #3761
