### PR TITLE
BUG: WIP: fix vtkPickingManager interaction with widgets

### DIFF
--- a/Interaction/Widgets/vtkAbstractPolygonalHandleRepresentation3D.cxx
+++ b/Interaction/Widgets/vtkAbstractPolygonalHandleRepresentation3D.cxx
@@ -73,6 +73,7 @@ vtkAbstractPolygonalHandleRepresentation3D
 
   // Manage the picking stuff
   this->HandlePicker = vtkCellPicker::New();
+  vtkDebugMacro("making picker " << this->HandlePicker << " in vtkAbstractPolygonalHandleRepresentation3D");
   this->HandlePicker->PickFromListOn();
   this->HandlePicker->SetTolerance(0.01); //need some fluff
 
@@ -123,6 +124,24 @@ void vtkAbstractPolygonalHandleRepresentation3D::RegisterPickers()
 {
   this->Renderer->GetRenderWindow()->GetInteractor()->GetPickingManager()
     ->AddPicker(this->HandlePicker, this);
+}
+
+//----------------------------------------------------------------------------
+void vtkAbstractPolygonalHandleRepresentation3D::UnRegisterPickers()
+{
+    if (this->Renderer &&
+        this->Renderer->GetRenderWindow() &&
+        this->Renderer->GetRenderWindow()->GetInteractor())
+      {
+      vtkPickingManager* pm = this->Renderer->GetRenderWindow()
+        ->GetInteractor()->GetPickingManager();
+      if (!pm)
+        {
+        return;
+        }
+
+      pm->RemovePicker(this->HandlePicker);
+      }
 }
 
 //----------------------------------------------------------------------

--- a/Interaction/Widgets/vtkAbstractPolygonalHandleRepresentation3D.h
+++ b/Interaction/Widgets/vtkAbstractPolygonalHandleRepresentation3D.h
@@ -164,8 +164,9 @@ protected:
   int                          WaitCount;
   int                          HandleVisibility;
 
-  // Register internal Pickers within PickingManager
+  // Register and Unregister internal Pickers within PickingManager
   virtual void RegisterPickers();
+  virtual void UnRegisterPickers();
 
   // Methods to manipulate the cursor
   virtual void Translate(double *p1, double *p2);

--- a/Interaction/Widgets/vtkOrientedPolygonalHandleRepresentation3D.cxx
+++ b/Interaction/Widgets/vtkOrientedPolygonalHandleRepresentation3D.cxx
@@ -42,6 +42,18 @@ vtkOrientedPolygonalHandleRepresentation3D
 }
 
 //----------------------------------------------------------------------
+void vtkOrientedPolygonalHandleRepresentation3D::EnablePicking()
+{
+  this->HandlePicker->SetEnabled(1);
+}
+
+//----------------------------------------------------------------------
+void vtkOrientedPolygonalHandleRepresentation3D::DisablePicking()
+{
+  this->HandlePicker->SetEnabled(0);
+}
+
+//----------------------------------------------------------------------
 void vtkOrientedPolygonalHandleRepresentation3D::UpdateHandle()
 {
   this->Superclass::UpdateHandle();

--- a/Interaction/Widgets/vtkOrientedPolygonalHandleRepresentation3D.h
+++ b/Interaction/Widgets/vtkOrientedPolygonalHandleRepresentation3D.h
@@ -46,6 +46,12 @@ public:
                        vtkAbstractPolygonalHandleRepresentation3D);
   void PrintSelf(ostream& os, vtkIndent indent);
 
+  // Description:
+  // Implement the virtual functions to manage internal pickers
+  // WIP: http://na-mic.org/Bug/view.php?id=3808
+  virtual void EnablePicking();
+  virtual void DisablePicking();
+
 protected:
   vtkOrientedPolygonalHandleRepresentation3D();
   ~vtkOrientedPolygonalHandleRepresentation3D();

--- a/Interaction/Widgets/vtkWidgetRepresentation.h
+++ b/Interaction/Widgets/vtkWidgetRepresentation.h
@@ -164,6 +164,18 @@ public:
   virtual int RenderVolumetricGeometry(vtkViewport *vtkNotUsed(viewport)) {return 0;}
   virtual int HasTranslucentPolygonalGeometry() { return 0; }
 
+
+  // WIP: related to http://na-mic.org/Bug/view.php?id=3808
+  // Since every widget manages it's own internal pickers, they
+  // need to explicitly enable/disable them so they won't
+  // interfere with the vtkPickingManager's work
+  virtual void EnablePicking() {
+    vtkErrorMacro("Subclass should allow enable/disable picking");
+  }
+  virtual void DisablePicking() {
+    vtkErrorMacro("Subclass should allow enable/disable picking");
+  }
+
 protected:
   vtkWidgetRepresentation();
   ~vtkWidgetRepresentation();

--- a/Rendering/Core/vtkAbstractPicker.cxx
+++ b/Rendering/Core/vtkAbstractPicker.cxx
@@ -34,6 +34,8 @@ vtkAbstractPicker::vtkAbstractPicker()
 
   this->PickFromList = 0;
   this->PickList = vtkPropCollection::New();
+
+  this->Enabled = 1;
 }
 
 vtkAbstractPicker::~vtkAbstractPicker()
@@ -98,4 +100,6 @@ void vtkAbstractPicker::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "Pick Position: (" <<  this->PickPosition[0] << ","
      << this->PickPosition[1] << ","
      << this->PickPosition[2] << ")\n";
+
+  os << indent << "Enabled: " << this->Enabled << "\n";
 }

--- a/Rendering/Core/vtkAbstractPicker.h
+++ b/Rendering/Core/vtkAbstractPicker.h
@@ -119,6 +119,14 @@ public:
   // Return the list of actors in the PickList.
   vtkPropCollection *GetPickList() {return this->PickList;}
 
+
+  // Description:
+  // Enable or disable picking for this picker (needed for vtkPickingManager)
+  // WIP: http://na-mic.org/Bug/view.php?id=3808
+  vtkSetMacro(Enabled,int);
+  vtkGetMacro(Enabled,int);
+  vtkBooleanMacro(Enabled,int);
+
 protected:
   vtkAbstractPicker();
   ~vtkAbstractPicker();
@@ -132,6 +140,8 @@ protected:
   // use the following to control picking from a list
   int PickFromList;
   vtkPropCollection *PickList;
+
+  int Enabled;
 private:
   vtkAbstractPicker(const vtkAbstractPicker&);  // Not implemented.
   void operator=(const vtkAbstractPicker&);  // Not implemented.


### PR DESCRIPTION
Adds options to explicitly enable and disable vtkAbstractPickers
so that the can be excluded from vtkPickingManager evaluations.

Updates vtkWidgetRepresentation so it can be told by when to
enable and disable any internally managed pickers.

Fixes the one class of pickers used in slicer so that version
4.4 can be released.

WIP: The changes in this commit should be evaluated in terms
of the vtk widget design and possibly picking can be automatically
handled as a byproduct of other calls such that EnablePicking and
DisablePicking are not needed in the public API.

See [1] for more discussion of the problem, along with a python
script that replicates the core issue that caused problem in slicer,
but using pure VTK.

http://na-mic.org/Bug/view.php?id=3808
