### PR TITLE
BUG: Fixed vtkImageReslice HitInputExtent update

### DIFF
--- a/Imaging/Core/vtkImageReslice.cxx
+++ b/Imaging/Core/vtkImageReslice.cxx
@@ -584,6 +584,7 @@ int vtkImageReslice::RequestUpdateExtent(
   vtkInformation *inInfo = inputVector[0]->GetInformationObject(0);
 
   outInfo->Get(vtkStreamingDemandDrivenPipeline::UPDATE_EXTENT(), outExt);
+  this->HitInputExtent = 1;
 
   if (this->ResliceTransform)
     {
@@ -705,7 +706,6 @@ int vtkImageReslice::RequestUpdateExtent(
   // Clip to whole extent, make sure we hit the extent
   int wholeExtent[6];
   inInfo->Get(vtkStreamingDemandDrivenPipeline::WHOLE_EXTENT(), wholeExtent);
-  this->HitInputExtent = 1;
 
   for (int k = 0; k < 3; k++)
     {


### PR DESCRIPTION
If this->ResliceTransform was not a vtkHomogeneousTransform then the whole input extent was updated and then the method immediately returned. However, the this->HitInputExtent flag was not updated. If the this->HitInputExtent had been 0 before then the output of the filter remained always 0 and the output of the filter was always empty.

Discussed with David Gobbi and he confirmed that this is a suitable fix.

Fixes http://na-mic.org/Mantis/view.php?id=3993
