### PR TITLE
COMP: Fix HAVE_ROUND macro redefinition build warning on Visual Studio 2013

### DIFF
--- a/Utilities/Python/vtkPython.h
+++ b/Utilities/Python/vtkPython.h
@@ -73,7 +73,7 @@ they are system headers.  Do NOT add any #undef lines here.  */
 #endif
 
 #if defined(_MSC_VER) && _MSC_VER >= 1800
-#define HAVE_ROUND
+#define HAVE_ROUND 1
 #endif
 
 #include <Python.h>


### PR DESCRIPTION
When built with certain versions of Python, the VTK build results in
many build warnings like:

```
c:\dev\sn\python-install\include\pyconfig.h(445): warning C4005: 'HAVE_ROUND' : macro redefinition [C:\dev\SN\VTKv6-build\Wrapping\Python\vtkCommonKitPythonD.vcxproj]
        C:\dev\SN\VTKv6\Utilities\Python\vtkPython.h(76) : see previous definition of 'HAVE_ROUND'
```

This warning occurs when both vtkPython.h and Python.h define the
HAVE_ROUND macro, but the definitions don't match. Python 2.7.9+ and
Python 3.4+ define HAVE_ROUND when compiling with Visual Studio 2013
(see http://bugs.python.org/issue21958).

This commit removes the build warnings by changing VTK's HAVE_ROUND
macro definition to be consistent with Python's definition.

Note that VTK master is not affected when built with Python 3 after the following commit:
https://gitlab.kitware.com/vtk/vtk/commit/d3eb40431868497b1b6fac86ba0d2da257ce2fa9
