### PR TITLE
ENH: Allow selection of seed points using vtkSeedWidget

### DIFF
--- a/Interaction/Widgets/vtkHandleWidget.cxx
+++ b/Interaction/Widgets/vtkHandleWidget.cxx
@@ -57,6 +57,7 @@ vtkHandleWidget::vtkHandleWidget()
                                           vtkWidgetEvent::Move,
                                           this, vtkHandleWidget::MoveAction);
   this->EnableAxisConstraint = 1;
+  this->EnableTranslation = 1;
   this->AllowHandleResize    = 1;
 }
 
@@ -247,6 +248,11 @@ void vtkHandleWidget::MoveAction(vtkAbstractWidget *w)
       {
       self->Render();
       }
+    return;
+    }
+
+  if (!self->EnableTranslation)
+    {
     return;
     }
 

--- a/Interaction/Widgets/vtkHandleWidget.h
+++ b/Interaction/Widgets/vtkHandleWidget.h
@@ -102,6 +102,11 @@ public:
   vtkGetMacro( EnableAxisConstraint, int );
   vtkBooleanMacro( EnableAxisConstraint, int );
 
+  // Enable moving of handles. By default, the handle can be moved.
+  vtkSetMacro(EnableTranslation, int);
+  vtkGetMacro(EnableTranslation, int);
+  vtkBooleanMacro(EnableTranslation, int);
+
   // Description:
   // Allow resizing of handles ? By default the right mouse button scales
   // the handle size.
@@ -134,6 +139,7 @@ protected:
 
   int WidgetState;
   int EnableAxisConstraint;
+  int EnableTranslation;
 
   // Allow resizing of handles.
   int AllowHandleResize;

--- a/Interaction/Widgets/vtkSeedWidget.cxx
+++ b/Interaction/Widgets/vtkSeedWidget.cxx
@@ -168,8 +168,10 @@ void vtkSeedWidget::AddPointAction(vtkAbstractWidget *w)
     // Invoke an event on ourself for the handles
     self->InvokeEvent(vtkCommand::LeftButtonPressEvent,NULL);
     self->Superclass::StartInteraction();
-    self->InvokeEvent(vtkCommand::StartInteractionEvent,NULL);
-
+    vtkSeedRepresentation *rep = static_cast<
+      vtkSeedRepresentation * >(self->WidgetRep);
+    int seedIdx = rep->GetActiveHandle();
+    self->InvokeEvent(vtkCommand::StartInteractionEvent, &seedIdx);
     self->EventCallbackCommand->SetAbortFlag(1);
     self->Render();
     }


### PR DESCRIPTION
In several use cases in 3D Slicer we need to be able to select a seed point, without allowing it to be moved.
Added EnableTranslation (true by default) member to vtkHandleWidget to allow locking a handle but still process events (to be able to detect when the user clicks on the handle).
Added seed index to StartInteractionEvent invoked in vtkSeedWidget.
