### PR TITLE
BUG: Enabling the use of Qt > 5.6 in the VTK 6.3 branch

### DIFF
--- a/GUISupport/QtWebkit/CMakeLists.txt
+++ b/GUISupport/QtWebkit/CMakeLists.txt
@@ -2,24 +2,30 @@ include(vtkQt)
 
 # Rich-text view requires Qt >= 4.5.0
 # Rich-text depends on Qt Webkit which is not portable on Unix (AIX & HP-UX)
+# Rich-test is not available in Qt > 5.6 as QtWebKit has been removed
 
 set(LibSrcs ${QVTKLibSrcs} vtkQtRichTextView.cxx)
 set(MocHeaders ${QVTKMocHeaders} vtkQtRichTextView.h)
 
 if(VTK_QT_VERSION VERSION_GREATER "4")
-  find_package(Qt5 COMPONENTS WebKitWidgets REQUIRED QUIET)
-  include_directories(${Qt5WebKitWidgets_INCLUDE_DIRS})
-  add_definitions(${Qt5WebKitWidgets_DEFINITIONS})
+  find_package(Qt5 COMPONENTS WebKitWidgets QUIET)
+  if(Qt5WebKitWidgets_FOUND)
+    include_directories(${Qt5WebKitWidgets_INCLUDE_DIRS})
+    add_definitions(${Qt5WebKitWidgets_DEFINITIONS})
 
-  qt5_wrap_ui(UI_FILES vtkQtRichTextView.ui)
-  qt5_wrap_cpp(LibMocSrcs ${MocHeaders})
+    qt5_wrap_ui(UI_FILES vtkQtRichTextView.ui)
+    qt5_wrap_cpp(LibMocSrcs ${MocHeaders})
 
-  set(QT_LIBRARIES ${Qt5WebKitWidgets_LIBRARIES})
+    set(QT_LIBRARIES ${Qt5WebKitWidgets_LIBRARIES})
 
-  # When this module is loaded by an app, load Qt too.
-  vtk_module_export_code_find_package(Qt5WebKitWidgets)
+    # When this module is loaded by an app, load Qt too.
+    vtk_module_export_code_find_package(Qt5WebKitWidgets)
+    set(_FOUND 1)
+  else()
+    message(STATUS "Qt5WebKitWidgets not found. vtkQtRichTextView is disabled.")
+  endif()
 else()
-  find_package(Qt4 REQUIRED QtCore QtGui QtWebKit QUIET)
+  find_package(Qt4 COMPONENTS QtCore QtGui QtWebKit QUIET)
 
   # import Qt4 build settings
   if(QT_PHONON_FOUND AND APPLE)
@@ -31,9 +37,14 @@ else()
 
   qt4_wrap_ui(UI_FILES vtkQtRichTextView.ui)
   qt4_wrap_cpp(LibMocSrcs ${MocHeaders})
+  if (QT_WEBKIT_FOUND)
+    set(_FOUND 1)
+  endif()
 endif()
 
-set(${vtk-module}_NO_HeaderTest 1)
-vtk_module_library(${vtk-module} ${LibSrcs} ${UI_FILES} ${LibMocSrcs})
+if(${_FOUND})
+  set(${vtk-module}_NO_HeaderTest 1)
+  vtk_module_library(${vtk-module} ${LibSrcs} ${UI_FILES} ${LibMocSrcs})
 
-vtk_module_link_libraries(${vtk-module} LINK_PRIVATE ${QT_LIBRARIES})
+  vtk_module_link_libraries(${vtk-module} LINK_PRIVATE ${QT_LIBRARIES})
+endif()


### PR DESCRIPTION
Using a more recent version of CMakeLists.txt that includes logic for QtWebKit presence checking.
