### PR TITLE
BUG: Fixed interactionState computation in SeedWidget

### DIFF
--- a/Interaction/Widgets/vtkSeedWidget.cxx
+++ b/Interaction/Widgets/vtkSeedWidget.cxx
@@ -155,6 +155,8 @@ void vtkSeedWidget::AddPointAction(vtkAbstractWidget *w)
     return;
     }
 
+  self->InvokeEvent(vtkCommand::MouseMoveEvent, NULL);
+
   // compute some info we need for all cases
   int X = self->Interactor->GetEventPosition()[0];
   int Y = self->Interactor->GetEventPosition()[1];


### PR DESCRIPTION
When a context menu is displayed over a VTK render window when the mouse was over a seed widget, the VTK window does not get MouseMove events anymore.
If the user clicks outside the context menu to close it, the VTK render window receives the click event.

vtkSeedWidget ignored the click position and assumed that the mouse pointer was still at the same position of the last MouseMove event (and made the context menu appear again, because it sensed it as a click on a seed).

Fixed by forcing update of interactionState using current mouse position in vtkSeedWidget::AddPointAction, the same way as it is already done in vtkSeedWidget::MoveAction.

How to reproduce the problem in Slicer:

1. Add two markup fiducials

2. Copy-paste to Python console:

<pre>
menu = qt.QMenu()
menu.addAction(qt.QAction("test", slicer.util.mainWindow()))
menu.addAction(qt.QAction("some", slicer.util.mainWindow()))
menu.addAction(qt.QAction("menu options", slicer.util.mainWindow()))

@vtk.calldata_type(vtk.VTK_INT)
def markupClickedCallback(caller, eventId, callData):
  menu.move(qt.QCursor.pos())
  menu.show()

markupsNode = getNode('F')
observerTag = markupsNode.AddObserver(slicer.vtkMRMLMarkupsNode.PointClickedEvent, markupClickedCallback)
</pre>

3. Click on a fiducial => context menu displayed

4. Click somewhere else in the same VTK window, outside the context menu
=> ERROR! The context menu is displayed again (it should have been closed)