### PR TITLE
Support python callback null calldata

### DIFF
--- a/Wrapping/PythonCore/vtkPythonCommand.cxx
+++ b/Wrapping/PythonCore/vtkPythonCommand.cxx
@@ -143,7 +143,7 @@ void vtkPythonCommand::Execute(vtkObject *ptr, unsigned long eventtype,
     {
       long callDataTypeLong = PyInt_AsLong(callDataTypeObj);
       int invalid = (callDataTypeLong == -1) && PyErr_Occurred();
-      if (!invalid)
+      if (!invalid && callData != nullptr)
       {
         if (callDataTypeLong == VTK_STRING)
         {


### PR DESCRIPTION
With calldata support, the calldata was always expect to be valid. This
would create a crash when trying to reinterpret_cast a null pointer.

VTK PR here: https://gitlab.kitware.com/vtk/vtk/merge_requests/4513

CC: @jcfr, @lassoan