### PR TITLE
COMP: fix extension configure error with CMake 3.15.2

### DIFF
--- a/CMake/FindPythonLibs.cmake
+++ b/CMake/FindPythonLibs.cmake
@@ -123,8 +123,8 @@ foreach(_CURRENT_VERSION ${_Python_VERSIONS})
 
     # Use the library's install prefix as a hint
     set(_Python_INCLUDE_PATH_HINT)
-    get_filename_component(_Python_PREFIX ${PYTHON_LIBRARY} PATH)
-    get_filename_component(_Python_PREFIX ${_Python_PREFIX} PATH)
+    get_filename_component(_Python_PREFIX "${PYTHON_LIBRARY}" PATH)
+    get_filename_component(_Python_PREFIX "${_Python_PREFIX}" PATH)
     if(_Python_PREFIX)
       set(_Python_INCLUDE_PATH_HINT ${_Python_PREFIX}/include)
     endif()


### PR DESCRIPTION
```text
PYTHON_LIBRARY: optimized;C:/a/Sw/python-install/libs/python36.lib;debug;C:/a/Sw//python-install/libs/python36.lib

CMake Error at C:/a/Sw/VTK/CMake/FindPythonLibs.cmake:127 (get_filename_component):
  get_filename_component unknown component
  C:/a/Sw/python-install/libs/python36.lib
Call Stack (most recent call first):
  C:/a/Sw/Slicer-build/SlicerConfig.cmake:952 (find_package)
  CMakeLists.txt:17 (find_package)

CMake Error at C:/a/Sw/VTK/CMake/FindPythonLibs.cmake:128 (get_filename_component):
  get_filename_component called with incorrect number of arguments
Call Stack (most recent call first):
  C:/a/Sw/Slicer-build/SlicerConfig.cmake:952 (find_package)
  CMakeLists.txt:17 (find_package)
```