### PR TITLE
[backport MR-6943] Qt 5.15 needs the include file QPainterPath

### DIFF
--- a/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
+++ b/Rendering/Qt/vtkQtLabelRenderStrategy.cxx
@@ -40,6 +40,7 @@
 #include <QImage>
 #include <QMap>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPair>
 #include <QPixmap>
 #include <QTextDocument>

--- a/Rendering/Qt/vtkQtStringToImage.cxx
+++ b/Rendering/Qt/vtkQtStringToImage.cxx
@@ -31,6 +31,7 @@
 #include <QFontMetrics>
 #include <QImage>
 #include <QPainter>
+#include <QPainterPath>
 #include <QPixmap>
 #include <QTextDocument>
 #include <QTextStream>


### PR DESCRIPTION
Cherry-picked commit 797f28697d5ba50c1fa2bc5596af626a3c277826 from main VTK repository.

These changes are needed to build VTK successfully with Qt 5.15.0.