### PR TITLE
Allow Slicer VTK to build with gcc 10.1 on Arch Linux.

### DIFF
--- a/ThirdParty/exodusII/update.sh
+++ b/ThirdParty/exodusII/update.sh
@@ -8,7 +8,7 @@ readonly name="exodusII"
 readonly ownership="Seacas Upstream <kwrobot@kitware.com>"
 readonly subtree="ThirdParty/$name/vtk$name"
 readonly repo="https://gitlab.kitware.com/third-party/seacas.git"
-readonly tag="for/vtk-old"
+readonly tag="for/vtk-20200128-7.24f-v2019-12-18"
 readonly paths="
 packages/seacas/libraries/exodus/CMakeLists.vtk.txt
 packages/seacas/libraries/exodus/cmake/exodus_config.h.in

--- a/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
+++ b/ThirdParty/exodusII/vtkexodusII/src/ex_create_par.c
@@ -614,5 +614,5 @@ int ex_create_par_int(const char *path, int cmode, int *comp_ws, int *io_ws, MPI
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_create_par;
 #endif

--- a/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
+++ b/ThirdParty/exodusII/vtkexodusII/src/ex_open_par.c
@@ -474,5 +474,5 @@ int ex_open_par_int(const char *path, int mode, int *comp_ws, int *io_ws, float 
  * Prevent warning in some versions of ranlib(1) because the object
  * file has no symbols.
  */
-const char exodus_unused_symbol_dummy_1;
+const char exodus_unused_symbol_dummy_ex_open_par;
 #endif


### PR DESCRIPTION
Original discussion and source of original patch from Kitware :

https://discourse.slicer.org/t/build-fails-in-vtkexodus-on-linux/12018