### PR TITLE
Slicer v9.0.20201111 733234c785 add vtk 4.2 writer

### DIFF
--- a/IO/Image/vtkBMPReader.cxx
+++ b/IO/Image/vtkBMPReader.cxx
@@ -23,14 +23,6 @@
 
 vtkStandardNewMacro(vtkBMPReader);
 
-#ifdef read
-#undef read
-#endif
-
-#ifdef close
-#undef close
-#endif
-
 vtkBMPReader::vtkBMPReader()
 {
   this->Colors = nullptr;

--- a/IO/Image/vtkImageReader.cxx
+++ b/IO/Image/vtkImageReader.cxx
@@ -28,14 +28,6 @@ vtkObjectFactoryNewMacro(vtkImageReader);
 
 vtkCxxSetObjectMacro(vtkImageReader, Transform, vtkTransform);
 
-#ifdef read
-#undef read
-#endif
-
-#ifdef close
-#undef close
-#endif
-
 //------------------------------------------------------------------------------
 vtkImageReader::vtkImageReader()
 {

--- a/IO/Image/vtkImageReader2.cxx
+++ b/IO/Image/vtkImageReader2.cxx
@@ -32,14 +32,6 @@
 
 vtkStandardNewMacro(vtkImageReader2);
 
-#ifdef read
-#undef read
-#endif
-
-#ifdef close
-#undef close
-#endif
-
 //------------------------------------------------------------------------------
 vtkImageReader2::vtkImageReader2()
 {

--- a/IO/Image/vtkPNMWriter.cxx
+++ b/IO/Image/vtkPNMWriter.cxx
@@ -21,14 +21,6 @@
 
 vtkStandardNewMacro(vtkPNMWriter);
 
-#ifdef write
-#undef write
-#endif
-
-#ifdef close
-#undef close
-#endif
-
 void vtkPNMWriter::WriteFileHeader(ostream* file, vtkImageData* cache, int wExt[6])
 {
   int min1 = wExt[0], max1 = wExt[1], min2 = wExt[2], max2 = wExt[3];

--- a/IO/Legacy/Testing/Python/CMakeLists.txt
+++ b/IO/Legacy/Testing/Python/CMakeLists.txt
@@ -3,4 +3,5 @@ vtk_add_test_python(
   TestExtentWriting.py,NO_DATA,NO_VALID,NO_OUTPUT
   TestFileSeries.py,NO_VALID,NO_OUTPUT
   TestGraphWriterReader.py,NO_DATA,NO_VALID,NO_OUTPUT
+  TestVTKLegacy.py,NO_DATA,NO_VALID,NO_OUTPUT
 )

--- a/IO/Legacy/Testing/Python/TestVTKLegacy.py
+++ b/IO/Legacy/Testing/Python/TestVTKLegacy.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+import vtk
+import sys
+
+# Test writing out / reading of legacy VTK files. Currently
+# tests: vtkPolyData, vtkUnstructuredGrid, vtkStructuredPoints,
+# vtkStructuredGrid, vtkRectilinearGrid.
+
+# Test vtkPolyData
+sphere = vtk.vtkSphereSource()
+sphere.SetThetaResolution(8)
+sphere.SetPhiResolution(4)
+
+# Write / read polygonal data - legacy version
+print("I/O vtkPolyData")
+wpd = vtk.vtkPolyDataWriter()
+wpd.SetFileVersion(42)
+wpd.WriteToOutputStringOn()
+wpd.SetInputConnection(sphere.GetOutputPort())
+wpd.Write()
+
+legacyOutStr = wpd.GetOutputString()
+#print(legacyOutStr)
+
+rpd = vtk.vtkPolyDataReader()
+rpd.ReadFromInputStringOn()
+rpd.SetInputString(legacyOutStr)
+rpd.Update()
+
+print("Writing / reading version 4.2")
+print("Major Version: ",rpd.GetFileMajorVersion())
+print("Minor Version: ",rpd.GetFileMinorVersion())
+print("File Version: ",rpd.GetFileVersion())
+
+# Write / read polygonal data - latest version
+wpd.SetFileVersion(51)
+wpd.Write()
+
+outStr = wpd.GetOutputString()
+#print(outStr)
+
+rpd.SetInputString(outStr)
+rpd.Update()
+
+print("Writing / reading version 5.1")
+print("Major Version: ",rpd.GetFileMajorVersion())
+print("Minor Version: ",rpd.GetFileMinorVersion())
+print("File Version: ",rpd.GetFileVersion())
+
+# Compare the strings and make sure a version difference is published.
+if not "4.2" in legacyOutStr:
+    print("Bad legacy writer output")
+    sys.exit(1)
+
+if not "5.1" in outStr:
+    print("Bad writer output")
+    sys.exit(1)
+
+# Write / read unstructured data - legacy version
+# Convert polydata to unstructured grid
+print("\nI/O vtkUnstructuredGrid")
+sph = vtk.vtkSphere()
+sph.SetRadius(10000000)
+extract = vtk.vtkExtractGeometry()
+extract.SetInputConnection(sphere.GetOutputPort())
+extract.SetImplicitFunction(sph)
+
+wug = vtk.vtkUnstructuredGridWriter()
+wug.SetFileVersion(42)
+wug.WriteToOutputStringOn()
+wug.SetInputConnection(extract.GetOutputPort())
+wug.Write()
+
+legacyOutStr = wug.GetOutputString()
+#print(legacyOutStr)
+
+rug = vtk.vtkUnstructuredGridReader()
+rug.ReadFromInputStringOn()
+rug.SetInputString(legacyOutStr)
+rug.Update()
+
+print("Writing / reading version 4.2")
+print("Major Version: ",rug.GetFileMajorVersion())
+print("Minor Version: ",rug.GetFileMinorVersion())
+print("File Version: ",rug.GetFileVersion())
+
+# Write / read ustructured grid - latest version
+wug.SetFileVersion(51)
+wug.Write()
+
+outStr = wug.GetOutputString()
+#print(outStr)
+
+rug.SetInputString(outStr)
+rug.Update()
+
+print("Writing / reading version 5.1")
+print("Major Version: ",rug.GetFileMajorVersion())
+print("Minor Version: ",rug.GetFileMinorVersion())
+print("File Version: ",rug.GetFileVersion())
+
+# Compare the strings and make sure a version difference is published.
+if not "4.2" in legacyOutStr:
+    print("Bad legacy writer output")
+    sys.exit(1)
+
+if not "5.1" in outStr:
+    print("Bad writer output")
+    sys.exit(1)
+
+# vtkImageData
+print("\nI/O vtkStructuredPoints (aka vtkImageData)")
+img = vtk.vtkImageData()
+img.SetDimensions(3,4,5)
+img.AllocateScalars(4,1) #array of shorts
+num = 3*4*5
+s = img.GetPointData().GetScalars()
+for i in range(0,num):
+    s.SetValue(i,i)
+
+iw = vtk.vtkStructuredPointsWriter()
+iw.SetInputData(img)
+iw.SetFileVersion(42)
+iw.WriteToOutputStringOn()
+iw.Write()
+
+legacyOutStr = iw.GetOutputString()
+#print(legacyOutStr)
+
+ir = vtk.vtkStructuredPointsReader()
+ir.ReadFromInputStringOn()
+ir.SetInputString(legacyOutStr)
+ir.Update()
+
+print("Writing / reading version 4.2")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+iw.SetFileVersion(51)
+iw.Write()
+
+outStr = iw.GetOutputString()
+#print(outStr)
+
+ir.SetInputString(outStr)
+ir.Update()
+
+print("Writing / reading version 5.1")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+# Compare the strings and make sure a version difference is published.
+if not "4.2" in legacyOutStr:
+    print("Bad legacy writer output")
+    sys.exit(1)
+
+if not "5.1" in outStr:
+    print("Bad writer output")
+    sys.exit(1)
+
+# vtkStructuredGrid
+print("\nI/O vtkStructuredGrid")
+sg = vtk.vtkStructuredGrid()
+dims = [3,4,5]
+sg.SetDimensions(dims)
+num = dims[0]*dims[1]*dims[2]
+
+pts = vtk.vtkPoints()
+pts.SetNumberOfPoints(num)
+for k in range(0,dims[2]):
+    for j in range(0,dims[1]):
+        for i in range(0,dims[0]):
+            pId = i + j*dims[0] + k*dims[0]*dims[1]
+            pts.SetPoint(pId,i,j,k)
+sg.SetPoints(pts)
+
+sgs = vtk.vtkIntArray()
+sgs.SetNumberOfTuples(num)
+sg.GetPointData().SetScalars(sgs)
+for i in range(0,num):
+    sgs.SetValue(i,i)
+
+sgw = vtk.vtkStructuredGridWriter()
+sgw.SetInputData(sg)
+sgw.SetFileVersion(42)
+sgw.WriteToOutputStringOn()
+sgw.Write()
+
+legacyOutStr = sgw.GetOutputString()
+#print(legacyOutStr)
+
+ir = vtk.vtkStructuredGridReader()
+ir.ReadFromInputStringOn()
+ir.SetInputString(legacyOutStr)
+ir.Update()
+
+print("Writing / reading version 4.2")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+sgw.SetFileVersion(51)
+sgw.Write()
+
+outStr = sgw.GetOutputString()
+#print(outStr)
+
+ir.SetInputString(outStr)
+ir.Update()
+
+print("Writing / reading version 5.1")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+# Compare the strings and make sure a version difference is published.
+if not "4.2" in legacyOutStr:
+    print("Bad legacy writer output")
+    sys.exit(1)
+
+if not "5.1" in outStr:
+    print("Bad writer output")
+    sys.exit(1)
+
+# vtkRectilinearGrid
+print("\nI/O vtkRectilinearGrid")
+rg = vtk.vtkRectilinearGrid()
+dims = [3,4,5]
+rg.SetDimensions(dims)
+num = dims[0]*dims[1]*dims[2]
+
+xPts = vtk.vtkFloatArray()
+xPts.SetNumberOfTuples(dims[0])
+yPts = vtk.vtkFloatArray()
+yPts.SetNumberOfTuples(dims[1])
+zPts = vtk.vtkFloatArray()
+zPts.SetNumberOfTuples(dims[2])
+
+for i in range(0,dims[0]):
+    xPts.SetTuple1(i,i)
+for j in range(0,dims[1]):
+    yPts.SetTuple1(j,j)
+for k in range(0,dims[2]):
+    zPts.SetTuple1(k,k)
+
+rg.SetXCoordinates(xPts)
+rg.SetYCoordinates(yPts)
+rg.SetZCoordinates(zPts)
+
+rgs = vtk.vtkIntArray()
+rgs.SetNumberOfTuples(num)
+rg.GetPointData().SetScalars(rgs)
+for i in range(0,num):
+    rgs.SetValue(i,i)
+
+rgw = vtk.vtkRectilinearGridWriter()
+rgw.SetInputData(rg)
+rgw.SetFileVersion(42)
+rgw.WriteToOutputStringOn()
+rgw.Write()
+
+legacyOutStr = rgw.GetOutputString()
+#print(legacyOutStr)
+
+ir = vtk.vtkRectilinearGridReader()
+ir.ReadFromInputStringOn()
+ir.SetInputString(legacyOutStr)
+ir.Update()
+
+print("Writing / reading version 4.2")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+rgw.SetFileVersion(51)
+rgw.Write()
+
+outStr = rgw.GetOutputString()
+#print(outStr)
+
+ir.SetInputString(outStr)
+ir.Update()
+
+print("Writing / reading version 5.1")
+print("Major Version: ",ir.GetFileMajorVersion())
+print("Minor Version: ",ir.GetFileMinorVersion())
+print("File Version: ",ir.GetFileVersion())
+
+# Compare the strings and make sure a version difference is published.
+if not "4.2" in legacyOutStr:
+    print("Bad legacy writer output")
+    sys.exit(1)
+
+if not "5.1" in outStr:
+    print("Bad writer output")
+    sys.exit(1)
+
+print("\nSuccessful read / write")
+sys.exit(0)

--- a/IO/Legacy/vtkDataReader.cxx
+++ b/IO/Legacy/vtkDataReader.cxx
@@ -77,9 +77,11 @@ vtkStandardNewMacro(vtkDataReader);
 
 vtkCxxSetObjectMacro(vtkDataReader, InputArray, vtkCharArray);
 
+//------------------------------------------------------------------------------
 // Construct object.
 vtkDataReader::vtkDataReader()
 {
+  this->FileVersion = 0;
   this->FileType = VTK_ASCII;
   this->ScalarsName = nullptr;
   this->VectorsName = nullptr;
@@ -131,6 +133,7 @@ vtkDataReader::vtkDataReader()
   this->SetNumberOfOutputPorts(1);
 }
 
+//------------------------------------------------------------------------------
 vtkDataReader::~vtkDataReader()
 {
   delete[] this->ScalarsName;
@@ -149,6 +152,7 @@ vtkDataReader::~vtkDataReader()
   delete this->IS;
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::SetFileName(const char* fname)
 {
   if (this->GetNumberOfFileNames() == 1 && this->GetFileName(0) && fname &&
@@ -164,6 +168,7 @@ void vtkDataReader::SetFileName(const char* fname)
   this->Modified();
 }
 
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetFileName() const
 {
   if (this->GetNumberOfFileNames() < 1)
@@ -173,6 +178,7 @@ const char* vtkDataReader::GetFileName() const
   return this->vtkSimpleReader::GetFileName(0);
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadTimeDependentMetaData(int timestep, vtkInformation* metadata)
 {
   if (this->ReadFromInputString)
@@ -183,6 +189,7 @@ int vtkDataReader::ReadTimeDependentMetaData(int timestep, vtkInformation* metad
   return this->Superclass::ReadTimeDependentMetaData(timestep, metadata);
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadMesh(
   int piece, int npieces, int nghosts, int timestep, vtkDataObject* output)
 {
@@ -201,6 +208,7 @@ int vtkDataReader::ReadMesh(
   return this->Superclass::ReadMesh(piece, npieces, nghosts, timestep, output);
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::SetInputString(const char* in)
 {
   int len = 0;
@@ -211,11 +219,13 @@ void vtkDataReader::SetInputString(const char* in)
   this->SetInputString(in, len);
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::SetBinaryInputString(const char* in, int len)
 {
   this->SetInputString(in, len);
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::SetInputString(const char* in, int len)
 {
   if (this->Debug)
@@ -250,6 +260,7 @@ void vtkDataReader::SetInputString(const char* in, int len)
   this->Modified();
 }
 
+//------------------------------------------------------------------------------
 // Internal function to read in a line up to 256 characters.
 // Returns zero if there was an error.
 int vtkDataReader::ReadLine(char result[256])
@@ -277,6 +288,7 @@ int vtkDataReader::ReadLine(char result[256])
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Internal function to read in a string up to 256 characters.
 // Returns zero if there was an error.
 int vtkDataReader::ReadString(char result[256])
@@ -290,6 +302,7 @@ int vtkDataReader::ReadString(char result[256])
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Internal function to read in an integer value.
 // Returns zero if there was an error.
 int vtkDataReader::Read(char* result)
@@ -305,6 +318,7 @@ int vtkDataReader::Read(char* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(unsigned char* result)
 {
   int intData;
@@ -318,6 +332,7 @@ int vtkDataReader::Read(unsigned char* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(short* result)
 {
   *this->IS >> *result;
@@ -328,6 +343,7 @@ int vtkDataReader::Read(short* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(unsigned short* result)
 {
   *this->IS >> *result;
@@ -338,6 +354,7 @@ int vtkDataReader::Read(unsigned short* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(int* result)
 {
   *this->IS >> *result;
@@ -348,6 +365,7 @@ int vtkDataReader::Read(int* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(unsigned int* result)
 {
   *this->IS >> *result;
@@ -358,6 +376,7 @@ int vtkDataReader::Read(unsigned int* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(long* result)
 {
   *this->IS >> *result;
@@ -368,6 +387,7 @@ int vtkDataReader::Read(long* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(unsigned long* result)
 {
   *this->IS >> *result;
@@ -378,6 +398,7 @@ int vtkDataReader::Read(unsigned long* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(long long* result)
 {
   *this->IS >> *result;
@@ -388,6 +409,7 @@ int vtkDataReader::Read(long long* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(unsigned long long* result)
 {
   *this->IS >> *result;
@@ -398,6 +420,7 @@ int vtkDataReader::Read(unsigned long long* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(float* result)
 {
   *this->IS >> *result;
@@ -408,6 +431,7 @@ int vtkDataReader::Read(float* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::Read(double* result)
 {
   *this->IS >> *result;
@@ -418,6 +442,7 @@ int vtkDataReader::Read(double* result)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 size_t vtkDataReader::Peek(char* str, size_t n)
 {
   if (n == 0)
@@ -438,6 +463,7 @@ size_t vtkDataReader::Peek(char* str, size_t n)
   return len;
 }
 
+//------------------------------------------------------------------------------
 // Open a vtk data file. Returns zero if error.
 int vtkDataReader::OpenVTKFile(const char* fname)
 {
@@ -510,6 +536,7 @@ int vtkDataReader::OpenVTKFile(const char* fname)
   return 0;
 }
 
+//------------------------------------------------------------------------------
 // Read the header of a vtk data file. Returns 0 if error.
 int vtkDataReader::ReadHeader(const char* fname)
 {
@@ -556,6 +583,8 @@ int vtkDataReader::ReadHeader(const char* fname)
                     << this->FileMinorVersion << " with older reader version "
                     << vtkLegacyReaderMajorVersion << "." << vtkLegacyReaderMinorVersion);
   }
+  // Compose FileVersion
+  this->FileVersion = 10 * this->FileMajorVersion + this->FileMinorVersion;
 
   //
   // read title
@@ -632,6 +661,7 @@ int vtkDataReader::ReadHeader(const char* fname)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::IsFileValid(const char* dstype)
 {
   char line[1024];
@@ -678,6 +708,7 @@ int vtkDataReader::IsFileValid(const char* dstype)
   return 0;
 }
 
+//------------------------------------------------------------------------------
 // Read the cell data of a vtk data file. The number of cells (from the
 // dataset) must match the number of cells defined in cell attributes (unless
 // no geometry was defined).
@@ -836,6 +867,7 @@ int vtkDataReader::ReadCellData(vtkDataSet* ds, vtkIdType numCells)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read the point data of a vtk data file. The number of points (from the
 // dataset) must match the number of points defined in point attributes (unless
 // no geometry was defined).
@@ -1004,6 +1036,7 @@ int vtkDataReader::ReadPointData(vtkDataSet* ds, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read the vertex data of a vtk data file. The number of vertices (from the
 // graph) must match the number of vertices defined in vertex attributes (unless
 // no geometry was defined).
@@ -1162,6 +1195,7 @@ int vtkDataReader::ReadVertexData(vtkGraph* g, vtkIdType numVertices)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read the edge data of a vtk data file. The number of edges (from the
 // graph) must match the number of edges defined in edge attributes (unless
 // no geometry was defined).
@@ -1320,6 +1354,7 @@ int vtkDataReader::ReadEdgeData(vtkGraph* g, vtkIdType numEdges)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read the row data of a vtk data file.
 int vtkDataReader::ReadRowData(vtkTable* t, vtkIdType numEdges)
 {
@@ -1504,6 +1539,7 @@ int vtkReadASCIIData(vtkDataReader* self, T* data, vtkIdType numTuples, vtkIdTyp
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Description:
 // Read data array. Return pointer to array object if successful read;
 // otherwise return nullptr. Note: this method instantiates a reference counted
@@ -2135,6 +2171,7 @@ vtkAbstractArray* vtkDataReader::ReadArray(
   return array;
 }
 
+//------------------------------------------------------------------------------
 // Read point coordinates. Return 0 if error.
 int vtkDataReader::ReadPointCoordinates(vtkPointSet* ps, vtkIdType numPts)
 {
@@ -2170,6 +2207,7 @@ int vtkDataReader::ReadPointCoordinates(vtkPointSet* ps, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read point coordinates. Return 0 if error.
 int vtkDataReader::ReadPointCoordinates(vtkGraph* g, vtkIdType numPts)
 {
@@ -2205,6 +2243,7 @@ int vtkDataReader::ReadPointCoordinates(vtkGraph* g, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read the coordinates for a rectilinear grid. The axes parameter specifies
 // which coordinate axes (0,1,2) is being read.
 int vtkDataReader::ReadCoordinates(vtkRectilinearGrid* rg, int axes, int numCoords)
@@ -2248,6 +2287,7 @@ int vtkDataReader::ReadCoordinates(vtkRectilinearGrid* rg, int axes, int numCoor
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read scalar point attributes. Return 0 if error.
 int vtkDataReader::ReadScalarData(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2341,6 +2381,7 @@ int vtkDataReader::ReadScalarData(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read vector point attributes. Return 0 if error.
 int vtkDataReader::ReadVectorData(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2392,6 +2433,7 @@ int vtkDataReader::ReadVectorData(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read normal point attributes. Return 0 if error.
 int vtkDataReader::ReadNormalData(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2443,6 +2485,7 @@ int vtkDataReader::ReadNormalData(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read tensor point attributes. Return 0 if error.
 int vtkDataReader::ReadTensorData(vtkDataSetAttributes* a, vtkIdType numPts, vtkIdType numComp)
 {
@@ -2493,6 +2536,7 @@ int vtkDataReader::ReadTensorData(vtkDataSetAttributes* a, vtkIdType numPts, vtk
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read color scalar point attributes. Return 0 if error.
 int vtkDataReader::ReadCoScalarData(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2589,6 +2633,7 @@ int vtkDataReader::ReadCoScalarData(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read texture coordinates point attributes. Return 0 if error.
 int vtkDataReader::ReadTCoordsData(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2649,6 +2694,7 @@ int vtkDataReader::ReadTCoordsData(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read texture coordinates point attributes. Return 0 if error.
 int vtkDataReader::ReadGlobalIds(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2695,6 +2741,7 @@ int vtkDataReader::ReadGlobalIds(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read pedigree ids. Return 0 if error.
 int vtkDataReader::ReadPedigreeIds(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2741,6 +2788,7 @@ int vtkDataReader::ReadPedigreeIds(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read edge flags. Return 0 if error.
 int vtkDataReader::ReadEdgeFlags(vtkDataSetAttributes* a, vtkIdType numPts)
 {
@@ -2787,6 +2835,7 @@ int vtkDataReader::ReadEdgeFlags(vtkDataSetAttributes* a, vtkIdType numPts)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadInformation(vtkInformation* info, vtkIdType numKeys)
 {
   // Assuming that the opening INFORMATION line has been read.
@@ -3044,6 +3093,7 @@ int vtkDataReader::ReadInformation(vtkInformation* info, vtkIdType numKeys)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read lookup table. Return 0 if error.
 int vtkDataReader::ReadLutData(vtkDataSetAttributes* a)
 {
@@ -3114,6 +3164,7 @@ int vtkDataReader::ReadLutData(vtkDataSetAttributes* a)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadCells(vtkSmartPointer<vtkCellArray>& cellArray)
 {
   vtkIdType offsetsSize{ 0 };
@@ -3194,6 +3245,7 @@ int vtkDataReader::ReadCells(vtkSmartPointer<vtkCellArray>& cellArray)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 // Read lookup table. Return 0 if error.
 int vtkDataReader::ReadCellsLegacy(vtkIdType size, int* data)
 {
@@ -3234,6 +3286,7 @@ int vtkDataReader::ReadCellsLegacy(vtkIdType size, int* data)
   return 1;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadCellsLegacy(vtkIdType size, int* data, int skip1, int read2, int skip3)
 {
   char line[256];
@@ -3346,6 +3399,7 @@ int vtkDataReader::ReadCellsLegacy(vtkIdType size, int* data, int skip1, int rea
   return 1;
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::ConvertGhostLevelsToGhostType(FieldType fieldType, vtkAbstractArray* data) const
 {
   vtkUnsignedCharArray* ucData = vtkArrayDownCast<vtkUnsignedCharArray>(data);
@@ -3374,6 +3428,7 @@ void vtkDataReader::ConvertGhostLevelsToGhostType(FieldType fieldType, vtkAbstra
   }
 }
 
+//------------------------------------------------------------------------------
 vtkFieldData* vtkDataReader::ReadFieldData(FieldType fieldType)
 {
   int i, numArrays = 0, skipField = 0;
@@ -3441,6 +3496,7 @@ vtkFieldData* vtkDataReader::ReadFieldData(FieldType fieldType)
   }
 }
 
+//------------------------------------------------------------------------------
 char* vtkDataReader::LowerCase(char* str, const size_t len)
 {
   size_t i;
@@ -3465,6 +3521,7 @@ void vtkDataReader::CloseVTKFile()
   this->IS = nullptr;
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::InitializeCharacteristics()
 {
   int i;
@@ -3537,6 +3594,7 @@ void vtkDataReader::InitializeCharacteristics()
   }
 }
 
+//------------------------------------------------------------------------------
 // read entire file, storing important characteristics
 int vtkDataReader::CharacterizeFile()
 {
@@ -3576,6 +3634,7 @@ int vtkDataReader::CharacterizeFile()
   return 1;
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::CheckFor(const char* name, char* line, int& num, char**& array, int& allocSize)
 {
   if (!strncmp(this->LowerCase(line, strlen(name)), name, strlen(name)))
@@ -3624,6 +3683,7 @@ void vtkDataReader::CheckFor(const char* name, char* line, int& num, char**& arr
   } // found one
 }
 
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetScalarsNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3637,6 +3697,7 @@ const char* vtkDataReader::GetScalarsNameInFile(int i)
   }
 }
 
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetVectorsNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3649,6 +3710,7 @@ const char* vtkDataReader::GetVectorsNameInFile(int i)
     return this->VectorsNameInFile[i];
   }
 }
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetTensorsNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3661,6 +3723,7 @@ const char* vtkDataReader::GetTensorsNameInFile(int i)
     return this->TensorsNameInFile[i];
   }
 }
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetNormalsNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3673,6 +3736,7 @@ const char* vtkDataReader::GetNormalsNameInFile(int i)
     return this->NormalsNameInFile[i];
   }
 }
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetTCoordsNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3685,6 +3749,7 @@ const char* vtkDataReader::GetTCoordsNameInFile(int i)
     return this->TCoordsNameInFile[i];
   }
 }
+//------------------------------------------------------------------------------
 const char* vtkDataReader::GetFieldDataNameInFile(int i)
 {
   this->CharacterizeFile();
@@ -3698,6 +3763,7 @@ const char* vtkDataReader::GetFieldDataNameInFile(int i)
   }
 }
 
+//------------------------------------------------------------------------------
 vtkTypeBool vtkDataReader::ProcessRequest(
   vtkInformation* request, vtkInformationVector** inputVector, vtkInformationVector* outputVector)
 {
@@ -3721,9 +3787,12 @@ vtkTypeBool vtkDataReader::ProcessRequest(
   return this->Superclass::ProcessRequest(request, inputVector, outputVector);
 }
 
+//------------------------------------------------------------------------------
 void vtkDataReader::PrintSelf(ostream& os, vtkIndent indent)
 {
   this->Superclass::PrintSelf(os, indent);
+
+  os << indent << "File Version: " << this->FileVersion << "\n";
 
   if (this->FileType == VTK_BINARY)
   {
@@ -3839,11 +3908,13 @@ void vtkDataReader::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "InputStringLength: " << this->InputStringLength << endl;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::ReadDataSetData(vtkDataSet* vtkNotUsed(ds))
 {
   return 0;
 }
 
+//------------------------------------------------------------------------------
 int vtkDataReader::DecodeString(char* resname, const char* name)
 {
   if (!resname || !name)

--- a/IO/Legacy/vtkDataReader.cxx
+++ b/IO/Legacy/vtkDataReader.cxx
@@ -77,13 +77,6 @@ vtkStandardNewMacro(vtkDataReader);
 
 vtkCxxSetObjectMacro(vtkDataReader, InputArray, vtkCharArray);
 
-// this undef is required on the hp. vtkMutexLock ends up including
-// /usr/include/dce/cma_ux.h which has the gall to #define read as cma_read
-
-#ifdef read
-#undef read
-#endif
-
 // Construct object.
 vtkDataReader::vtkDataReader()
 {

--- a/IO/Legacy/vtkDataReader.h
+++ b/IO/Legacy/vtkDataReader.h
@@ -78,6 +78,23 @@ public:
 
   //@{
   /**
+   * Return the version of the file read; for example, VTK legacy readers
+   * will return the version of the VTK legacy file. (In the case of VTK
+   * legacy files, see vtkDataWriter.h for the enum types returned.) This
+   * method only returns useful information after a successful read is
+   * performed; and some derived classes may not return relevant
+   * information.) Note that for VTK legacy readers, the FileVersion is
+   * defined by the compositing the major version digits with the minor
+   * version digit. Extremely ancient VTK files (e.g., before version 4.2)
+   * will return a FileVersion of 3.0.
+   */
+  vtkGetMacro(FileVersion, int);
+  vtkGetMacro(FileMajorVersion, int);
+  vtkGetMacro(FileMinorVersion, int);
+  //@}
+
+  //@{
+  /**
    * Is the file a valid vtk file of the passed dataset type ?
    * The dataset type is passed as a lower case string.
    */
@@ -410,15 +427,6 @@ public:
 
   //@{
   /**
-   * Return major and minor version of the file.
-   * Returns version 3.0 if the version cannot be read from file.
-   */
-  vtkGetMacro(FileMajorVersion, int);
-  vtkGetMacro(FileMinorVersion, int);
-  //@}
-
-  //@{
-  /**
    * Internal function to read in a value.  Returns zero if there was an
    * error.
    */
@@ -510,6 +518,9 @@ protected:
   ~vtkDataReader() override;
 
   std::string CurrentFileName;
+  int FileVersion;
+  int FileMajorVersion;
+  int FileMinorVersion;
   int FileType;
   istream* IS;
 
@@ -578,8 +589,6 @@ protected:
   vtkTypeBool ReadAllColorScalars;
   vtkTypeBool ReadAllTCoords;
   vtkTypeBool ReadAllFields;
-  int FileMajorVersion;
-  int FileMinorVersion;
 
   std::locale CurrentLocale;
 

--- a/IO/Legacy/vtkDataWriter.cxx
+++ b/IO/Legacy/vtkDataWriter.cxx
@@ -71,13 +71,6 @@
 
 vtkStandardNewMacro(vtkDataWriter);
 
-// this undef is required on the hp. vtkMutexLock ends up including
-// /usr/include/dce/cma_ux.h which has the gall to #define write as cma_write
-
-#ifdef write
-#undef write
-#endif
-
 // Created object with default header, ASCII format, and default names for
 // scalars, vectors, tensors, normals, and texture coordinates.
 vtkDataWriter::vtkDataWriter()

--- a/IO/Legacy/vtkDataWriter.h
+++ b/IO/Legacy/vtkDataWriter.h
@@ -14,11 +14,11 @@
 =========================================================================*/
 /**
  * @class   vtkDataWriter
- * @brief   helper class for objects that write vtk data files
+ * @brief   helper class for objects that write VTK data files
  *
- * vtkDataWriter is a helper class that opens and writes the vtk header and
+ * vtkDataWriter is a helper class that opens and writes the VTK header and
  * point data (e.g., scalars, vectors, normals, etc.) from a vtk data file.
- * See text for various formats.
+ * See the VTK textbook and online resources for various formats.
  *
  * @sa
  * vtkDataSetWriter vtkPolyDataWriter vtkStructuredGridWriter
@@ -47,21 +47,53 @@ class vtkTable;
 class VTKIOLEGACY_EXPORT vtkDataWriter : public vtkWriter
 {
 public:
+  //@{
+  /**
+   * Standard methods for type information and printing.
+   */
   vtkTypeMacro(vtkDataWriter, vtkWriter);
   void PrintSelf(ostream& os, vtkIndent indent) override;
+  //@}
 
   /**
-   * Created object with default header, ASCII format, and default names for
+   * Create object with default header, ASCII format, and default names for
    * scalars, vectors, tensors, normals, and texture coordinates.
    */
   static vtkDataWriter* New();
 
   //@{
   /**
-   * Specify file name of vtk polygon data file to write.
+   * Specify the file name of VTK data file to write.
    */
   vtkSetStringMacro(FileName);
   vtkGetStringMacro(FileName);
+  //@}
+
+  // Currently VTK can write out two different versions of file format: files
+  // of VTK reader version 4.2 and previous; and VTK reader version 5.1 and
+  // later. This will likely change in the future. (Note: the major
+  // difference in the two formats is the way cell arrays are written out.)
+  // By default, Version 5.1 files are written out.
+  enum VTKFileVersion
+  {
+    VTK_LEGACY_READER_VERSION_4_2 = 42,
+    VTK_LEGACY_READER_VERSION_5_1 = 51
+  };
+
+  //@{
+  /**
+   * Specify the VTK file version to write. See the enum documentaion above
+   * (VTKFileVersion) for additional information about supported versions.
+   * It is possible to get the file major and minor versions separately.  See
+   * also vtkDataReader for related methods. (Note, the parsing of the
+   * FileVersion into major and minor version is as follows: the least
+   * significant digit is the minor version; the remaining digits are the
+   * major version.
+   */
+  void SetFileVersion(int);
+  vtkGetMacro(FileVersion, int);
+  vtkGetMacro(FileMajorVersion, int);
+  vtkGetMacro(FileMinorVersion, int);
   //@}
 
   //@{
@@ -102,7 +134,7 @@ public:
 
   //@{
   /**
-   * Specify the header for the vtk data file.
+   * Specify the header for the VTK data file.
    */
   vtkSetStringMacro(Header);
   vtkGetStringMacro(Header);
@@ -111,7 +143,7 @@ public:
   //@{
   /**
    * If true, vtkInformation objects attached to arrays and array component
-   * nameswill be written to the output. Default is true.
+   * nameswill be written to the output. The default is true.
    */
   vtkSetMacro(WriteArrayMetaData, bool);
   vtkGetMacro(WriteArrayMetaData, bool);
@@ -120,7 +152,7 @@ public:
 
   //@{
   /**
-   * Specify file type (ASCII or BINARY) for vtk data file.
+   * Specify the file type (ASCII or BINARY) of the VTK data file.
    */
   vtkSetClampMacro(FileType, int, VTK_ASCII, VTK_BINARY);
   vtkGetMacro(FileType, int);
@@ -244,6 +276,12 @@ public:
   int WriteCells(ostream* fp, vtkCellArray* cells, const char* label);
 
   /**
+   * Write out the cells of the data set.
+   * @note Legacy implementation for file version < 5.0.
+   */
+  int WriteCellsLegacy(ostream* fp, vtkCellArray* cells, const char* label);
+
+  /**
    * Write the cell data (e.g., scalars, vectors, ...) of a vtk dataset.
    * Returns 0 if error.
    */
@@ -300,6 +338,9 @@ protected:
   void WriteData() override; // dummy method to allow this class to be instantiated and delegated to
 
   char* FileName;
+  int FileVersion;
+  int FileMajorVersion;
+  int FileMinorVersion;
   char* Header;
   int FileType;
 

--- a/IO/Parallel/vtkEnSightWriter.cxx
+++ b/IO/Parallel/vtkEnSightWriter.cxx
@@ -80,13 +80,6 @@
 #define VTK_QUADRATIC_PYRAMID 27
 #endif
 
-// this undef is required on the hp. vtkMutexLock ends up including
-// /usr/include/dce/cma_ux.h which has the gall to #define write as cma_write
-
-#ifdef write
-#undef write
-#endif
-
 //------------------------------------------------------------------------------
 vtkStandardNewMacro(vtkEnSightWriter);
 

--- a/IO/Parallel/vtkPImageWriter.cxx
+++ b/IO/Parallel/vtkPImageWriter.cxx
@@ -36,14 +36,6 @@
 
 vtkStandardNewMacro(vtkPImageWriter);
 
-#ifdef write
-#undef write
-#endif
-
-#ifdef close
-#undef close
-#endif
-
 //------------------------------------------------------------------------------
 vtkPImageWriter::vtkPImageWriter()
 {


### PR DESCRIPTION
By default, VTK9 saves meshes in file format that most VTK versions out there cannot read.
Backport a VTK feature that allows writing files in the older 4.2 format that is compatible with earlier Slicer versions and other applications.

The other commit is backported to avoid merge conflict