### PR TITLE
Faster coordinate transform v9 - WIP DO NOT MERGE

### DIFF
--- a/Common/Core/vtkWindow.cxx
+++ b/Common/Core/vtkWindow.cxx
@@ -54,9 +54,6 @@ vtkWindow::~vtkWindow()
 //------------------------------------------------------------------------------
 int* vtkWindow::GetSize()
 {
-  this->TileSize[0] = this->Size[0] * this->TileScale[0];
-  this->TileSize[1] = this->Size[1] * this->TileScale[1];
-
   return this->TileSize;
 }
 
@@ -81,6 +78,7 @@ void vtkWindow::SetSize(int width, int height)
   {
     this->Size[0] = width;
     this->Size[1] = height;
+    this->ComputeTileSize();
     this->Modified();
     this->InvokeEvent(vtkCommand::WindowResizeEvent, nullptr);
   }

--- a/Common/Core/vtkWindow.h
+++ b/Common/Core/vtkWindow.h
@@ -249,7 +249,19 @@ public:
    * have no impact. It is just in handling annotation that this information
    * must be available to the mappers and the coordinate calculations.
    */
-  vtkSetVector2Macro(TileScale, int);
+  inline virtual void SetTileScale(int _arg1, int _arg2)
+  {
+    vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting " << TileScale " to ("
+                  << _arg1 << "," << _arg2 << ")");
+    if ((this->TileScale[0] != _arg1) || (this->TileScale[1] != _arg2))
+    {
+      this->TileScale[0] = _arg1;
+      this->TileScale[1] = _arg2;
+      this->ComputeTileSize();
+      this->Modified();
+    }
+  }
+  void SetTileScale(const int _arg[2]) { this->SetTileScale(_arg[0], _arg[1]); }
   vtkGetVector2Macro(TileScale, int);
   void SetTileScale(int s) { this->SetTileScale(s, s); }
   vtkSetVector4Macro(TileViewport, double);
@@ -259,6 +271,12 @@ public:
 protected:
   vtkWindow();
   ~vtkWindow() override;
+
+  inline void ComputeTileSize()
+  {
+    this->TileSize[0] = this->Size[0] * this->TileScale[0];
+    this->TileSize[1] = this->Size[1] * this->TileScale[1];
+  }
 
   char* WindowName;
   int Size[2];

--- a/Common/Core/vtkWindow.h
+++ b/Common/Core/vtkWindow.h
@@ -251,7 +251,7 @@ public:
    */
   inline virtual void SetTileScale(int _arg1, int _arg2)
   {
-    vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting " << TileScale " to ("
+    vtkDebugMacro(<< this->GetClassName() << " (" << this << "): setting " << TileScale << " to ("
                   << _arg1 << "," << _arg2 << ")");
     if ((this->TileScale[0] != _arg1) || (this->TileScale[1] != _arg2))
     {

--- a/Common/Math/vtkMatrix4x4.h
+++ b/Common/Math/vtkMatrix4x4.h
@@ -276,6 +276,7 @@ inline void vtkMatrix4x4::MultiplyAndTranspose4x4(
 inline void vtkMatrix4x4::Multiply4x4(const vtkMatrix4x4* a, const vtkMatrix4x4* b, vtkMatrix4x4* c)
 {
   vtkMatrix4x4::Multiply4x4(*a->Element, *b->Element, *c->Element);
+  c->Modified();
 }
 
 //----------------------------------------------------------------------------

--- a/Common/Transforms/vtkTransform.h
+++ b/Common/Transforms/vtkTransform.h
@@ -431,6 +431,24 @@ public:
   }
   //@}
 
+  inline static void Multiply4x4(const vtkMatrix4x4* a, const vtkMatrix4x4* b, vtkTransform* c)
+  {
+    vtkMatrix4x4::Multiply4x4(a, b, c->GetMatrix());
+    c->MatrixUpdateMTime = c->Matrix->GetMTime();
+  }
+  inline static void Multiply4x4(vtkTransform* a, vtkTransform* b, vtkTransform* c)
+  {
+    Multiply4x4(a->GetMatrix(), b->GetMatrix(), c);
+  }
+  inline static void Multiply4x4(const vtkMatrix4x4* a, vtkTransform* b, vtkTransform* c)
+  {
+    Multiply4x4(a, b->GetMatrix(), c);
+  }
+  inline static void Multiply4x4(vtkTransform* a, const vtkMatrix4x4* b, vtkTransform* c)
+  {
+    Multiply4x4(a->GetMatrix(), b, c);
+  }
+
 protected:
   vtkTransform();
   ~vtkTransform() override;

--- a/Rendering/Core/vtkCamera.cxx
+++ b/Rendering/Core/vtkCamera.cxx
@@ -540,8 +540,8 @@ void vtkCamera::ComputeModelViewMatrix()
   if (this->ModelViewTransform->GetMTime() < this->ModelTransformMatrix->GetMTime() ||
     this->ModelViewTransform->GetMTime() < this->ViewTransform->GetMTime())
   {
-    vtkMatrix4x4::Multiply4x4(this->ViewTransform->GetMatrix(), this->ModelTransformMatrix,
-      this->ModelViewTransform->GetMatrix());
+    vtkTransform::Multiply4x4(this->ViewTransform, this->ModelTransformMatrix,
+      this->ModelViewTransform);
   }
 }
 

--- a/Rendering/Core/vtkRenderer.cxx
+++ b/Rendering/Core/vtkRenderer.cxx
@@ -1424,7 +1424,7 @@ void vtkRenderer::WorldToView()
 // Convert world point coordinates to view coordinates.
 void vtkRenderer::WorldToView(double& x, double& y, double& z)
 {
-  double     view[4];
+  double view[4];
 
   // get the perspective transformation from the active camera
   if (!this->ActiveCamera)
@@ -1476,7 +1476,7 @@ void vtkRenderer::WorldToPose(double& x, double& y, double& z)
 
 void vtkRenderer::PoseToView(double& x, double& y, double& z)
 {
-  double     view[4];
+  double view[4];
 
   // get the perspective transformation from the active camera
   if (!this->ActiveCamera)

--- a/Rendering/Core/vtkRenderer.h
+++ b/Rendering/Core/vtkRenderer.h
@@ -926,6 +926,60 @@ protected:
   vtkPropCollection* GL2PSSpecialPropCollection;
 
   /**
+   * Cache of CompositeProjectionTransformationMatrix from this->LastCompositeProjectionTransformationMatrixCamera.
+   */
+  double CompositeProjectionTransformationMatrix[16];
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->CompositeProjectionTransformationMatrix.
+   */
+  double LastCompositeProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Camera used to get the transform in this->CompositeProjectionTransformationMatrix.
+   */
+  vtkCamera* LastCompositeProjectionTransformationMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->CompositeProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastCompositeProjectionTransformationMatrixCameraModified;
+
+  /**
+   * Cache of ProjectionTransformationMatrix from this->LastProjectionTransformationMatrixCamera.
+   */
+  double ProjectionTransformationMatrix[16];
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->ProjectionTransformationMatrix.
+   */
+  double LastProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Camera used to get the transform in this->ProjectionTransformationMatrix.
+   */
+  vtkCamera* LastProjectionTransformationMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->ProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastProjectionTransformationMatrixCameraModified;
+
+
+  /**
+   * Gets the ActiveCamera CompositeProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetCompositeProjectionTransformationMatrix();
+
+  /**
+   * Gets the ActiveCamera ProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetProjectionTransformationMatrix();
+
+
+  /**
    * Ask all props to update and draw any opaque and translucent
    * geometry. This includes both vtkActors and vtkVolumes
    * Returns the number of props that rendered geometry.

--- a/Rendering/Core/vtkRenderer.h
+++ b/Rendering/Core/vtkRenderer.h
@@ -965,6 +965,20 @@ protected:
    */
   vtkMTimeType LastProjectionTransformationMatrixCameraModified;
 
+  /**
+   * Cache of ViewTransformMatrix from this->LastViewTransformMatrixCamera.
+   */
+  double ViewTransformMatrix[16];
+
+  /**
+   * Camera used to get the transform in this->ViewTransformMatrix.
+   */
+  vtkCamera* LastViewTransformMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->ViewTransformMatrix was set.
+   */
+  vtkMTimeType LastViewTransformCameraModified;
 
   /**
    * Gets the ActiveCamera CompositeProjectionTransformationMatrix, only computing it if necessary.
@@ -978,6 +992,11 @@ protected:
    */
   double* GetProjectionTransformationMatrix();
 
+  /**
+   * Gets the ActiveCamera ViewTransformMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetViewTransformMatrix();
 
   /**
    * Ask all props to update and draw any opaque and translucent

--- a/Rendering/Core/vtkViewport.cxx
+++ b/Rendering/Core/vtkViewport.cxx
@@ -238,7 +238,16 @@ void vtkViewport::DisplayToView()
 // Convert view coordinates to display coordinates.
 void vtkViewport::ViewToDisplay()
 {
-  if (this->VTKWindow)
+  double x = this->ViewPoint[0];
+  double y = this->ViewPoint[1];
+  double z = this->ViewPoint[2];
+  this->ViewToDisplay(x, y, z);
+  this->SetDisplayPoint(x, y, z);
+}
+
+void vtkViewport::ViewToDisplay(double &x, double &y, double &z)
+{
+  if ( this->VTKWindow )
   {
     double dx, dy;
     int sizex, sizey;
@@ -252,12 +261,16 @@ void vtkViewport::ViewToDisplay()
     sizex = size[0];
     sizey = size[1];
 
-    dx = (this->ViewPoint[0] + 1.0) * (sizex * (this->Viewport[2] - this->Viewport[0])) / 2.0 +
-      sizex * this->Viewport[0];
-    dy = (this->ViewPoint[1] + 1.0) * (sizey * (this->Viewport[3] - this->Viewport[1])) / 2.0 +
-      sizey * this->Viewport[1];
+    dx = (x + 1.0) *
+      (sizex*(this->Viewport[2]-this->Viewport[0])) / 2.0 +
+        sizex*this->Viewport[0];
+    dy = (y + 1.0) *
+      (sizey*(this->Viewport[3]-this->Viewport[1])) / 2.0 +
+        sizey*this->Viewport[1];
 
-    this->SetDisplayPoint(dx, dy, this->ViewPoint[2]);
+    x = dx;
+    y = dy;
+    //z = z; // this transform does not change the z
   }
 }
 

--- a/Rendering/Core/vtkViewport.h
+++ b/Rendering/Core/vtkViewport.h
@@ -412,6 +412,10 @@ protected:
   double ViewPoint[3];
   double WorldPoint[4];
 
+  int LastComputeAspectSize[2];
+  double LastComputeAspectVPort[4];
+  double LastComputeAspectPixelAspect[2];
+
 private:
   vtkViewport(const vtkViewport&) = delete;
   void operator=(const vtkViewport&) = delete;

--- a/Rendering/Core/vtkViewport.h
+++ b/Rendering/Core/vtkViewport.h
@@ -254,23 +254,23 @@ public:
    * only if the window has been realized (e.g., GetSize() returns
    * something other than (0,0)).
    */
-  virtual void LocalDisplayToDisplay(double &x, double &y);
-  virtual void DisplayToNormalizedDisplay(double &u, double &v);
-  virtual void NormalizedDisplayToViewport(double &x, double &y);
-  virtual void ViewportToNormalizedViewport(double &u, double &v);
-  virtual void NormalizedViewportToView(double &x, double &y, double &z);
-  virtual void ViewToPose(double &, double &, double &) {}
-  virtual void PoseToWorld(double &, double &, double &) {}
-  virtual void DisplayToLocalDisplay(double &x, double &y);
-  virtual void NormalizedDisplayToDisplay(double &u, double &v);
-  virtual void ViewportToNormalizedDisplay(double &x, double &y);
-  virtual void NormalizedViewportToViewport(double &u, double &v);
-  virtual void ViewToNormalizedViewport(double &x, double &y, double &z);
-  virtual void PoseToView(double &, double &, double &) {}
-  virtual void WorldToPose(double &, double &, double &) {}
-  virtual void ViewToWorld(double &, double &, double &) {}
-  virtual void WorldToView(double &, double &, double &) {}
-  virtual void ViewToDisplay(double &x, double &y, double &z);
+  virtual void LocalDisplayToDisplay(double& x, double& y);
+  virtual void DisplayToNormalizedDisplay(double& u, double& v);
+  virtual void NormalizedDisplayToViewport(double& x, double& y);
+  virtual void ViewportToNormalizedViewport(double& u, double& v);
+  virtual void NormalizedViewportToView(double& x, double& y, double& z);
+  virtual void ViewToPose(double&, double&, double&) {}
+  virtual void PoseToWorld(double&, double&, double&) {}
+  virtual void DisplayToLocalDisplay(double& x, double& y);
+  virtual void NormalizedDisplayToDisplay(double& u, double& v);
+  virtual void ViewportToNormalizedDisplay(double& x, double& y);
+  virtual void NormalizedViewportToViewport(double& u, double& v);
+  virtual void ViewToNormalizedViewport(double& x, double& y, double& z);
+  virtual void PoseToView(double&, double&, double&) {}
+  virtual void WorldToPose(double&, double&, double&) {}
+  virtual void ViewToWorld(double&, double&, double&) {}
+  virtual void WorldToView(double&, double&, double&) {}
+  virtual void ViewToDisplay(double& x, double& y, double& z);
   //@}
 
   //@{

--- a/Rendering/Core/vtkViewport.h
+++ b/Rendering/Core/vtkViewport.h
@@ -237,6 +237,15 @@ public:
     this->ViewToDisplay();
   }
 
+  /**
+   * Convert world point coordinates to display (or screen) coordinates.
+   */
+  inline void WorldToDisplay(double &x, double &y, double &z)
+  {
+    this->WorldToView(x, y, z);
+    this->ViewToDisplay(x, y, z);
+  }
+
   //@{
   /**
    * These methods map from one coordinate system to another.
@@ -245,22 +254,23 @@ public:
    * only if the window has been realized (e.g., GetSize() returns
    * something other than (0,0)).
    */
-  virtual void LocalDisplayToDisplay(double& x, double& y);
-  virtual void DisplayToNormalizedDisplay(double& u, double& v);
-  virtual void NormalizedDisplayToViewport(double& x, double& y);
-  virtual void ViewportToNormalizedViewport(double& u, double& v);
-  virtual void NormalizedViewportToView(double& x, double& y, double& z);
-  virtual void ViewToPose(double&, double&, double&) {}
-  virtual void PoseToWorld(double&, double&, double&) {}
-  virtual void DisplayToLocalDisplay(double& x, double& y);
-  virtual void NormalizedDisplayToDisplay(double& u, double& v);
-  virtual void ViewportToNormalizedDisplay(double& x, double& y);
-  virtual void NormalizedViewportToViewport(double& u, double& v);
-  virtual void ViewToNormalizedViewport(double& x, double& y, double& z);
-  virtual void PoseToView(double&, double&, double&) {}
-  virtual void WorldToPose(double&, double&, double&) {}
-  virtual void ViewToWorld(double&, double&, double&) {}
-  virtual void WorldToView(double&, double&, double&) {}
+  virtual void LocalDisplayToDisplay(double &x, double &y);
+  virtual void DisplayToNormalizedDisplay(double &u, double &v);
+  virtual void NormalizedDisplayToViewport(double &x, double &y);
+  virtual void ViewportToNormalizedViewport(double &u, double &v);
+  virtual void NormalizedViewportToView(double &x, double &y, double &z);
+  virtual void ViewToPose(double &, double &, double &) {}
+  virtual void PoseToWorld(double &, double &, double &) {}
+  virtual void DisplayToLocalDisplay(double &x, double &y);
+  virtual void NormalizedDisplayToDisplay(double &u, double &v);
+  virtual void ViewportToNormalizedDisplay(double &x, double &y);
+  virtual void NormalizedViewportToViewport(double &u, double &v);
+  virtual void ViewToNormalizedViewport(double &x, double &y, double &z);
+  virtual void PoseToView(double &, double &, double &) {}
+  virtual void WorldToPose(double &, double &, double &) {}
+  virtual void ViewToWorld(double &, double &, double &) {}
+  virtual void WorldToView(double &, double &, double &) {}
+  virtual void ViewToDisplay(double &x, double &y, double &z);
   //@}
 
   //@{


### PR DESCRIPTION
These updates were made while looking into issue https://github.com/Slicer/Slicer/issues/5752.

Before making any changes I was getting a render speed of ~2 FPS on a scene with 200 Fiducial Markup Nodes each with 1 control point (Slicer was build RelWithDebInfo). After making these changes and the changes in https://github.com/Slicer/Slicer/pull/5800 (which is dependent on this PR) I was getting render speeds of ~4-5 FPS, a decent improvement.