### PR TITLE
Slicer/improve rendering performance2

### DIFF
--- a/Common/Core/vtkWindow.cxx
+++ b/Common/Core/vtkWindow.cxx
@@ -52,16 +52,13 @@ vtkWindow::~vtkWindow()
 }
 
 //------------------------------------------------------------------------------
-int* vtkWindow::GetSize()
+const int* vtkWindow::GetSize()
 {
-  this->TileSize[0] = this->Size[0] * this->TileScale[0];
-  this->TileSize[1] = this->Size[1] * this->TileScale[1];
-
   return this->TileSize;
 }
 
 //------------------------------------------------------------------------------
-int* vtkWindow::GetActualSize()
+const int* vtkWindow::GetActualSize()
 {
   // Some subclasses override GetSize() to do some additional magic.
   this->GetSize();
@@ -79,11 +76,18 @@ void vtkWindow::SetSize(int width, int height)
 {
   if (this->Size[0] != width || this->Size[1] != height)
   {
-    this->Size[0] = width;
-    this->Size[1] = height;
+    this->SetSizeNoEvent(width, height);
     this->Modified();
     this->InvokeEvent(vtkCommand::WindowResizeEvent, nullptr);
   }
+}
+
+//------------------------------------------------------------------------------
+void vtkWindow::SetSizeNoEvent(int width, int height)
+{
+  this->Size[0] = width;
+  this->Size[1] = height;
+  this->ComputeTileSize();
 }
 
 //------------------------------------------------------------------------------

--- a/Filters/Hybrid/vtkRenderLargeImage.cxx
+++ b/Filters/Hybrid/vtkRenderLargeImage.cxx
@@ -178,7 +178,6 @@ void vtkRenderLargeImage::RequestData(vtkInformation* vtkNotUsed(request),
   data->AllocateScalars(outInfo);
   int inExtent[6];
   vtkIdType inIncr[3];
-  int* size;
   int inWindowExtent[4];
   double viewAngle, parallelScale, windowCenter[2];
   vtkCamera* cam;
@@ -204,7 +203,7 @@ void vtkRenderLargeImage::RequestData(vtkInformation* vtkNotUsed(request),
   data->GetIncrements(inIncr);
 
   // get the size of the render window
-  size = this->Input->GetRenderWindow()->GetSize();
+  const int* size = this->Input->GetRenderWindow()->GetSize();
 
   // convert the request into windows
   inWindowExtent[0] = inExtent[0] / size[0];

--- a/Interaction/Image/vtkImageViewer.h
+++ b/Interaction/Image/vtkImageViewer.h
@@ -123,7 +123,7 @@ public:
    * Get the size (width and height) of the rendering window in
    * screen coordinates (in pixels).
    */
-  int* GetSize() VTK_SIZEHINT(2) { return this->RenderWindow->GetSize(); }
+  const int* GetSize() VTK_SIZEHINT(2) { return this->RenderWindow->GetSize(); }
 
   /**
    * Set the size (width and height) of the rendering window in

--- a/Interaction/Image/vtkImageViewer2.cxx
+++ b/Interaction/Image/vtkImageViewer2.cxx
@@ -185,7 +185,7 @@ void vtkImageViewer2::SetSize(int width, int height)
 }
 
 //------------------------------------------------------------------------------
-int* vtkImageViewer2::GetSize()
+const int* vtkImageViewer2::GetSize()
 {
   return this->RenderWindow->GetSize();
 }

--- a/Interaction/Image/vtkImageViewer2.h
+++ b/Interaction/Image/vtkImageViewer2.h
@@ -199,7 +199,7 @@ public:
    * Get the size (width and height) of the rendering window in
    * screen coordinates (in pixels).
    */
-  virtual int* GetSize() VTK_SIZEHINT(2);
+  virtual const int* GetSize() VTK_SIZEHINT(2);
 
   /**
    * Set the size (width and height) of the rendering window in

--- a/Interaction/Widgets/vtkMagnifierRepresentation.cxx
+++ b/Interaction/Widgets/vtkMagnifierRepresentation.cxx
@@ -115,7 +115,7 @@ void vtkMagnifierRepresentation::WidgetInteraction(double eventPos[2])
   this->BuildRepresentation();
 
   // Move the viewport /renderer to the current mouse position
-  int* winSize = this->Renderer->GetRenderWindow()->GetSize();
+  const int* winSize = this->Renderer->GetRenderWindow()->GetSize();
   int* vpSize = this->Renderer->GetSize();
   double vpxMax = static_cast<double>(vpSize[0]) / winSize[0];
   double vpyMax = static_cast<double>(vpSize[1]) / winSize[1];

--- a/Interaction/Widgets/vtkTextRepresentation.cxx
+++ b/Interaction/Widgets/vtkTextRepresentation.cxx
@@ -290,7 +290,7 @@ void vtkTextRepresentation::CheckTextBoundary()
 
     // Convert padding in pixels into viewport
     // Multiply by 2 to ensure an even padding
-    int* size = win->GetSize();
+    const int* size = win->GetSize();
     double paddingX = 2 * this->RightPadding / (double)size[0];
     double paddingY = 2 * this->TopPadding / (double)size[1];
 

--- a/Rendering/Core/vtkRenderWindow.cxx
+++ b/Rendering/Core/vtkRenderWindow.cxx
@@ -274,7 +274,7 @@ void vtkRenderWindow::Render()
   // if SetSize has not yet been called (from a script, possible off
   // screen use, other scenarios?) then call it here with reasonable
   // default values
-  if (0 == this->Size[0] && 0 == this->Size[1])
+  if (0 == this->GetActualSizeDirectly()[0] && 0 == this->GetActualSizeDirectly()[1])
   {
     this->SetSize(300, 300);
   }
@@ -486,9 +486,8 @@ void vtkRenderWindow::StereoMidpoint()
     (this->StereoType == VTK_STEREO_CHECKERBOARD) ||
     (this->StereoType == VTK_STEREO_SPLITVIEWPORT_HORIZONTAL))
   {
-    int* size;
     // get the size
-    size = this->GetSize();
+    const int* size = this->GetSize();
     // get the data
     this->GetPixelData(0, 0, size[0] - 1, size[1] - 1, 0, this->StereoBuffer);
   }
@@ -548,10 +547,8 @@ void vtkRenderWindow::CopyResultFrame()
 {
   if (this->ResultFrame->GetNumberOfTuples() > 0)
   {
-    int* size;
-
     // get the size
-    size = this->GetSize();
+    const int* size = this->GetSize();
 
     assert(this->ResultFrame->GetNumberOfTuples() == size[0] * size[1]);
 

--- a/Rendering/Core/vtkRenderer.cxx
+++ b/Rendering/Core/vtkRenderer.cxx
@@ -1424,7 +1424,6 @@ void vtkRenderer::WorldToView()
 // Convert world point coordinates to view coordinates.
 void vtkRenderer::WorldToView(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1434,8 +1433,7 @@ void vtkRenderer::WorldToView(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(mat,
-    this->ActiveCamera->GetCompositeProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1));
+  double* mat = this->GetCompositeProjectionTransformationMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1452,7 +1450,6 @@ void vtkRenderer::WorldToView(double& x, double& y, double& z)
 
 void vtkRenderer::WorldToPose(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1462,7 +1459,7 @@ void vtkRenderer::WorldToPose(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(mat, this->ActiveCamera->GetViewTransformMatrix());
+  double* mat = this->GetViewTransformMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1479,7 +1476,6 @@ void vtkRenderer::WorldToPose(double& x, double& y, double& z)
 
 void vtkRenderer::PoseToView(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1489,8 +1485,7 @@ void vtkRenderer::PoseToView(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(
-    mat, this->ActiveCamera->GetProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1));
+  const double* mat = this->GetProjectionTransformationMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1518,10 +1513,10 @@ void vtkRenderer::PoseToWorld(double& x, double& y, double& z)
   }
 
   // get the perspective transformation from the active camera
-  vtkMatrix4x4* matrix = this->ActiveCamera->GetViewTransformMatrix();
+  double* matrix = this->GetViewTransformMatrix();
 
   // use the inverse matrix
-  vtkMatrix4x4::Invert(*matrix->Element, mat);
+  vtkMatrix4x4::Invert(matrix, mat);
 
   // Transform point to world coordinates
   result[0] = x;
@@ -1553,13 +1548,8 @@ void vtkRenderer::ViewToPose(double& x, double& y, double& z)
     return;
   }
 
-  // get the perspective transformation from the active camera
-  vtkMatrix4x4* matrix =
-    this->ActiveCamera->GetProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1);
-
-  // use the inverse matrix
-  vtkMatrix4x4::Invert(*matrix->Element, mat);
-
+  const double* matrix = this->GetProjectionTransformationMatrix();
+  vtkMatrix4x4::Invert(matrix, mat);
   // Transform point to world coordinates
   result[0] = x;
   result[1] = y;
@@ -1927,4 +1917,53 @@ int vtkRenderer::CaptureGL2PSSpecialProp(vtkProp* prop)
   return 0;
 }
 
-vtkCxxSetObjectMacro(vtkRenderer, GL2PSSpecialPropCollection, vtkPropCollection);
+vtkCxxSetObjectMacro(vtkRenderer, GL2PSSpecialPropCollection, vtkPropCollection)
+
+  double* vtkRenderer::GetViewTransformMatrix()
+{
+  if (this->ActiveCamera != this->LastViewTransformMatrixCamera ||
+    this->LastViewTransformCameraModified < this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(this->ViewTransformMatrix, this->ActiveCamera->GetViewTransformMatrix());
+
+    this->LastViewTransformMatrixCamera = this->ActiveCamera;
+    this->LastViewTransformCameraModified = this->ActiveCamera->GetMTime();
+  }
+  return this->ViewTransformMatrix;
+}
+
+double* vtkRenderer::GetCompositeProjectionTransformationMatrix()
+{
+  const double tiledAspectRatio = this->GetTiledAspectRatio();
+  if (tiledAspectRatio != this->LastCompositeProjectionTransformationMatrixTiledAspectRatio ||
+    this->ActiveCamera != this->LastCompositeProjectionTransformationMatrixCamera ||
+    this->LastCompositeProjectionTransformationMatrixCameraModified <
+      this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(this->CompositeProjectionTransformationMatrix,
+      this->ActiveCamera->GetCompositeProjectionTransformMatrix(tiledAspectRatio, 0, 1));
+
+    this->LastCompositeProjectionTransformationMatrixTiledAspectRatio = tiledAspectRatio;
+    this->LastCompositeProjectionTransformationMatrixCamera = this->ActiveCamera;
+    this->LastCompositeProjectionTransformationMatrixCameraModified =
+      this->ActiveCamera->GetMTime();
+  }
+  return this->CompositeProjectionTransformationMatrix;
+}
+
+double* vtkRenderer::GetProjectionTransformationMatrix()
+{
+  const double tiledAspectRatio = this->GetTiledAspectRatio();
+  if (tiledAspectRatio != this->LastProjectionTransformationMatrixTiledAspectRatio ||
+    this->ActiveCamera != this->LastProjectionTransformationMatrixCamera ||
+    this->LastProjectionTransformationMatrixCameraModified < this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(this->ProjectionTransformationMatrix,
+      this->ActiveCamera->GetProjectionTransformMatrix(tiledAspectRatio, 0, 1));
+
+    this->LastProjectionTransformationMatrixTiledAspectRatio = tiledAspectRatio;
+    this->LastProjectionTransformationMatrixCamera = this->ActiveCamera;
+    this->LastProjectionTransformationMatrixCameraModified = this->ActiveCamera->GetMTime();
+  }
+  return this->ProjectionTransformationMatrix;
+}

--- a/Rendering/Core/vtkRenderer.cxx
+++ b/Rendering/Core/vtkRenderer.cxx
@@ -263,7 +263,6 @@ void vtkRenderer::Render()
   double t1, t2;
   int i;
   vtkProp* aProp;
-  int* size;
 
   // If Draw is not on, ignore the render.
   if (!this->Draw)
@@ -276,7 +275,7 @@ void vtkRenderer::Render()
 
   this->InvokeEvent(vtkCommand::StartEvent, nullptr);
 
-  size = this->RenderWindow->GetSize();
+  const int* size = this->RenderWindow->GetSize();
 
   // if backing store is on and we have a stored image
   if (this->BackingStore && this->BackingImage && this->MTime < this->RenderTime &&

--- a/Rendering/Core/vtkRenderer.h
+++ b/Rendering/Core/vtkRenderer.h
@@ -926,6 +926,80 @@ protected:
   vtkPropCollection* GL2PSSpecialPropCollection;
 
   /**
+   * Cache of CompositeProjectionTransformationMatrix from
+   * this->LastCompositeProjectionTransformationMatrixCamera.
+   */
+  double CompositeProjectionTransformationMatrix[16];
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->CompositeProjectionTransformationMatrix.
+   */
+  double LastCompositeProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Camera used to get the transform in this->CompositeProjectionTransformationMatrix.
+   */
+  vtkCamera* LastCompositeProjectionTransformationMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->CompositeProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastCompositeProjectionTransformationMatrixCameraModified;
+
+  /**
+   * Cache of ProjectionTransformationMatrix from this->LastProjectionTransformationMatrixCamera.
+   */
+  double ProjectionTransformationMatrix[16];
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->ProjectionTransformationMatrix.
+   */
+  double LastProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Camera used to get the transform in this->ProjectionTransformationMatrix.
+   */
+  vtkCamera* LastProjectionTransformationMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->ProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastProjectionTransformationMatrixCameraModified;
+
+  /**
+   * Cache of ViewTransformMatrix from this->LastViewTransformMatrixCamera.
+   */
+  double ViewTransformMatrix[16];
+
+  /**
+   * Camera used to get the transform in this->ViewTransformMatrix.
+   */
+  vtkCamera* LastViewTransformMatrixCamera;
+
+  /**
+   * Modified time from the camera when this->ViewTransformMatrix was set.
+   */
+  vtkMTimeType LastViewTransformCameraModified;
+
+  /**
+   * Gets the ActiveCamera CompositeProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetCompositeProjectionTransformationMatrix();
+
+  /**
+   * Gets the ActiveCamera ProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetProjectionTransformationMatrix();
+
+  /**
+   * Gets the ActiveCamera ViewTransformMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  double* GetViewTransformMatrix();
+
+  /**
    * Ask all props to update and draw any opaque and translucent
    * geometry. This includes both vtkActors and vtkVolumes
    * Returns the number of props that rendered geometry.

--- a/Rendering/Core/vtkResizingWindowToImageFilter.cxx
+++ b/Rendering/Core/vtkResizingWindowToImageFilter.cxx
@@ -193,7 +193,7 @@ void vtkResizingWindowToImageFilter::RequestData(vtkInformation* vtkNotUsed(requ
   this->GetScaleFactorsAndSize(this->Size, newSize, scale, &approximate);
 
   // save window state
-  int* oldptr = renWin->GetSize();
+  const int* oldptr = renWin->GetSize();
   int oldSize[2] = { oldptr[0], oldptr[1] };
   bool oldOffScreen = renWin->GetUseOffScreenBuffers();
   vtkTypeBool oldSwap = renWin->GetSwapBuffers();

--- a/Rendering/Core/vtkViewport.cxx
+++ b/Rendering/Core/vtkViewport.cxx
@@ -21,6 +21,8 @@
 #include "vtkPropCollection.h"
 #include "vtkWindow.h"
 
+#include <algorithm>
+
 //------------------------------------------------------------------------------
 // Create a vtkViewport with a black background, a white ambient light,
 // two-sided lighting turned on, a viewport of (0,0,1,1), and backface culling
@@ -240,6 +242,18 @@ void vtkViewport::ViewToDisplay()
 {
   if (this->VTKWindow)
   {
+    double x = this->ViewPoint[0];
+    double y = this->ViewPoint[1];
+    double z = this->ViewPoint[2];
+    this->ViewToDisplay(x, y, z);
+    this->SetDisplayPoint(x, y, z);
+  }
+}
+
+void vtkViewport::ViewToDisplay(double& x, double& y, double& z)
+{
+  if (this->VTKWindow)
+  {
     double dx, dy;
     int sizex, sizey;
 
@@ -252,12 +266,14 @@ void vtkViewport::ViewToDisplay()
     sizex = size[0];
     sizey = size[1];
 
-    dx = (this->ViewPoint[0] + 1.0) * (sizex * (this->Viewport[2] - this->Viewport[0])) / 2.0 +
+    dx = (x + 1.0) * (sizex * (this->Viewport[2] - this->Viewport[0])) / 2.0 +
       sizex * this->Viewport[0];
-    dy = (this->ViewPoint[1] + 1.0) * (sizey * (this->Viewport[3] - this->Viewport[1])) / 2.0 +
+    dy = (y + 1.0) * (sizey * (this->Viewport[3] - this->Viewport[1])) / 2.0 +
       sizey * this->Viewport[1];
 
-    this->SetDisplayPoint(dx, dy, this->ViewPoint[2]);
+    x = dx;
+    y = dy;
+    // z = z; // this transform does not change the z
   }
 }
 
@@ -660,29 +676,40 @@ void vtkViewport::ComputeAspect()
     }
     double* vport = this->GetViewport();
 
-    int lowerLeft[2], upperRight[2];
-    lowerLeft[0] = static_cast<int>(vport[0] * size[0] + 0.5);
-    lowerLeft[1] = static_cast<int>(vport[1] * size[1] + 0.5);
-    upperRight[0] = static_cast<int>(vport[2] * size[0] + 0.5);
-    upperRight[1] = static_cast<int>(vport[3] * size[1] + 0.5);
-    upperRight[0]--;
-    upperRight[1]--;
-
-    double aspect[2];
-    if ((upperRight[0] - lowerLeft[0] + 1) != 0 && (upperRight[1] - lowerLeft[1] + 1) != 0)
+    if (!std::equal(size, size + 1, this->LastComputeAspectSize) ||
+      !std::equal(vport, vport + 3, this->LastComputeAspectVPort) ||
+      !std::equal(std::begin(this->PixelAspect), std::end(this->PixelAspect),
+        this->LastComputeAspectPixelAspect))
     {
-      aspect[0] = static_cast<double>(upperRight[0] - lowerLeft[0] + 1) /
-        static_cast<double>(upperRight[1] - lowerLeft[1] + 1) * this->PixelAspect[0];
-    }
-    else
-    {
-      // it happens if the vtkWindow is attached to the vtkViewport but
-      // the vtkWindow is not initialized yet, so size[0]==0 and size[1]==0
-      aspect[0] = this->PixelAspect[0];
-    }
-    aspect[1] = 1.0 * this->PixelAspect[1];
+      std::copy(size, size + 1, this->LastComputeAspectSize);
+      std::copy(vport, vport + 3, this->LastComputeAspectVPort);
+      std::copy(std::begin(this->PixelAspect), std::end(this->PixelAspect),
+        this->LastComputeAspectPixelAspect);
 
-    this->SetAspect(aspect);
+      int lowerLeft[2], upperRight[2];
+      lowerLeft[0] = static_cast<int>(vport[0] * size[0] + 0.5);
+      lowerLeft[1] = static_cast<int>(vport[1] * size[1] + 0.5);
+      upperRight[0] = static_cast<int>(vport[2] * size[0] + 0.5);
+      upperRight[1] = static_cast<int>(vport[3] * size[1] + 0.5);
+      upperRight[0]--;
+      upperRight[1]--;
+
+      double aspect[2];
+      if ((upperRight[0] - lowerLeft[0] + 1) != 0 && (upperRight[1] - lowerLeft[1] + 1) != 0)
+      {
+        aspect[0] = static_cast<double>(upperRight[0] - lowerLeft[0] + 1) /
+          static_cast<double>(upperRight[1] - lowerLeft[1] + 1) * this->PixelAspect[0];
+      }
+      else
+      {
+        // it happens if the vtkWindow is attached to the vtkViewport but
+        // the vtkWindow is not initialized yet, so size[0]==0 and size[1]==0
+        aspect[0] = this->PixelAspect[0];
+      }
+      aspect[1] = 1.0 * this->PixelAspect[1];
+
+      this->SetAspect(aspect);
+    }
   }
 }
 

--- a/Rendering/Core/vtkViewport.h
+++ b/Rendering/Core/vtkViewport.h
@@ -237,6 +237,15 @@ public:
     this->ViewToDisplay();
   }
 
+  /**
+   * Convert world point coordinates to display (or screen) coordinates.
+   */
+  inline void WorldToDisplay(double& x, double& y, double& z)
+  {
+    this->WorldToView(x, y, z);
+    this->ViewToDisplay(x, y, z);
+  }
+
   //@{
   /**
    * These methods map from one coordinate system to another.
@@ -261,6 +270,7 @@ public:
   virtual void WorldToPose(double&, double&, double&) {}
   virtual void ViewToWorld(double&, double&, double&) {}
   virtual void WorldToView(double&, double&, double&) {}
+  virtual void ViewToDisplay(double& x, double& y, double& z);
   //@}
 
   //@{
@@ -401,6 +411,10 @@ protected:
   double DisplayPoint[3];
   double ViewPoint[3];
   double WorldPoint[4];
+
+  int LastComputeAspectSize[2];
+  double LastComputeAspectVPort[4];
+  double LastComputeAspectPixelAspect[2];
 
 private:
   vtkViewport(const vtkViewport&) = delete;

--- a/Rendering/External/vtkExternalOpenGLRenderWindow.cxx
+++ b/Rendering/External/vtkExternalOpenGLRenderWindow.cxx
@@ -52,9 +52,10 @@ void vtkExternalOpenGLRenderWindow::Start(void)
   }
 
   // creates or resizes the framebuffer
-  this->Size[0] = (this->Size[0] > 0 ? this->Size[0] : 300);
-  this->Size[1] = (this->Size[1] > 0 ? this->Size[1] : 300);
-  this->CreateFramebuffers(this->Size[0], this->Size[1]);
+  this->SetSizeNoEvent(
+    (this->GetActualSizeDirectly()[0] > 0 ? this->GetActualSizeDirectly()[0] : 300),
+    (this->GetActualSizeDirectly()[1] > 0 ? this->GetActualSizeDirectly()[1] : 300));
+  this->CreateFramebuffers(this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 
   // For stereo, render the correct eye based on the OpenGL buffer mode
   GLint bufferType;

--- a/Rendering/OpenGL2/vtkCocoaRenderWindow.h
+++ b/Rendering/OpenGL2/vtkCocoaRenderWindow.h
@@ -114,7 +114,7 @@ public:
    * Get the size (width and height) of the rendering window in
    * screen coordinates (in pixels).
    */
-  int* GetSize() VTK_SIZEHINT(2) override;
+  const int* GetSize() VTK_SIZEHINT(2) override;
 
   //@{
   /**
@@ -130,7 +130,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenGL2/vtkEGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkEGLRenderWindow.cxx
@@ -244,9 +244,9 @@ void vtkEGLRenderWindow::SetSize(int width, int height)
     // We only need to resize the window if we own it
     int w, h;
     this->GetEGLSurfaceSize(&w, &h);
-    if (w != this->Size[0] || h != this->Size[1])
+    if (w != this->GetActualSizeDirectly()[0] || h != this->GetActualSizeDirectly()[1])
     {
-      this->ResizeWindow(this->Size[0], this->Size[1]);
+      this->ResizeWindow(this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
     }
   }
 }
@@ -254,10 +254,10 @@ void vtkEGLRenderWindow::SetSize(int width, int height)
 void vtkEGLRenderWindow::CreateAWindow()
 {
   int s[2];
-  if (this->Size[0] != 0 && this->Size[1] != 0)
+  if (this->GetActualSizeDirectly()[0] != 0 && this->GetActualSizeDirectly()[1] != 0)
   {
-    s[0] = this->Size[0];
-    s[1] = this->Size[1];
+    s[0] = this->GetActualSizeDirectly()[0];
+    s[1] = this->GetActualSizeDirectly()[1];
   }
   else
   {
@@ -581,7 +581,7 @@ bool vtkEGLRenderWindow::IsCurrent()
 }
 
 // Get the size of the screen in pixels
-int* vtkEGLRenderWindow::GetScreenSize()
+const int* vtkEGLRenderWindow::GetScreenSize()
 {
   // TODO: actually determine screensize.
 

--- a/Rendering/OpenGL2/vtkEGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkEGLRenderWindow.h
@@ -125,7 +125,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenGL2/vtkGenericOpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkGenericOpenGLRenderWindow.cxx
@@ -148,7 +148,7 @@ void vtkGenericOpenGLRenderWindow::SetWindowInfo(const char*) {}
 
 void vtkGenericOpenGLRenderWindow::SetParentInfo(const char*) {}
 
-int* vtkGenericOpenGLRenderWindow::GetScreenSize()
+const int* vtkGenericOpenGLRenderWindow::GetScreenSize()
 {
   return this->ScreenSize;
 }

--- a/Rendering/OpenGL2/vtkGenericOpenGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkGenericOpenGLRenderWindow.h
@@ -95,7 +95,7 @@ public:
   void* GetGenericDrawable() override;
   void SetWindowInfo(const char*) override;
   void SetParentInfo(const char*) override;
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
   void HideCursor() override;
   void ShowCursor() override;
   void SetFullScreen(vtkTypeBool) override;

--- a/Rendering/OpenGL2/vtkIOSRenderWindow.h
+++ b/Rendering/OpenGL2/vtkIOSRenderWindow.h
@@ -108,7 +108,7 @@ public:
    * Get the size (width and height) of the rendering window in
    * screen coordinates (in pixels).
    */
-  int* GetSize() VTK_SIZEHINT(2) override;
+  const int* GetSize() VTK_SIZEHINT(2) override;
 
   //@{
   /**
@@ -124,7 +124,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenGL2/vtkIOSRenderWindow.mm
+++ b/Rendering/OpenGL2/vtkIOSRenderWindow.mm
@@ -51,8 +51,10 @@ void vtkIOSRenderWindow::BlitDisplayFramebuffersToHardware()
   auto ostate = this->GetState();
   ostate->PushFramebufferBindings();
   this->DisplayFramebuffer->Bind(GL_READ_FRAMEBUFFER);
-  this->GetState()->vtkglViewport(0, 0, this->Size[0], this->Size[1]);
-  this->GetState()->vtkglScissor(0, 0, this->Size[0], this->Size[1]);
+  this->GetState()->vtkglViewport(
+    0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
+  this->GetState()->vtkglScissor(
+    0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 
   // recall Blit upper right corner is exclusive of the range
   const int srcExtents[4] = { 0, this->Size[0], 0, this->Size[1] };
@@ -258,11 +260,11 @@ vtkTypeBool vtkIOSRenderWindow::IsDirect()
 //----------------------------------------------------------------------------
 void vtkIOSRenderWindow::SetSize(int width, int height)
 {
-  if ((this->Size[0] != width) || (this->Size[1] != height) || this->GetParentId())
+  if ((this->GetActualSizeDirectly()[0] != width) || (this->GetActualSizeDirectly()[1] != height) ||
+    this->GetParentId())
   {
     this->Modified();
-    this->Size[0] = width;
-    this->Size[1] = height;
+    this->SetSizeNoEvent(width, height);
   }
 }
 
@@ -352,7 +354,7 @@ void vtkIOSRenderWindow::DestroyOffScreenWindow() {}
 
 //----------------------------------------------------------------------------
 // Get the current size of the window.
-int* vtkIOSRenderWindow::GetSize()
+const int* vtkIOSRenderWindow::GetSize()
 {
   // if we aren't mapped then just return call super
   if (!this->Mapped)
@@ -365,7 +367,7 @@ int* vtkIOSRenderWindow::GetSize()
 
 //----------------------------------------------------------------------------
 // Get the current size of the screen in pixels.
-int* vtkIOSRenderWindow::GetScreenSize()
+const int* vtkIOSRenderWindow::GetScreenSize()
 {
   // TODO: use UISceen to actually determine screen size.
 

--- a/Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkOSOpenGLRenderWindow.cxx
@@ -139,7 +139,7 @@ void vtkOSOpenGLRenderWindow::SetStereoCapableWindow(vtkTypeBool capable)
 
 void vtkOSOpenGLRenderWindow::CreateAWindow()
 {
-  this->CreateOffScreenWindow(this->Size[0], this->Size[1]);
+  this->CreateOffScreenWindow(this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 }
 
 void vtkOSOpenGLRenderWindow::DestroyWindow()
@@ -190,8 +190,7 @@ void vtkOSOpenGLRenderWindow::CreateOffScreenWindow(int width, int height)
   this->MakeCurrent();
 
   this->Mapped = 0;
-  this->Size[0] = width;
-  this->Size[1] = height;
+  this->SetSizeNoEvent(width, height);
 
   this->MakeCurrent();
 
@@ -260,8 +259,8 @@ void vtkOSOpenGLRenderWindow::Initialize(void)
   if (!(this->Internal->OffScreenContextId))
   {
     // initialize offscreen window
-    int width = ((this->Size[0] > 0) ? this->Size[0] : 300);
-    int height = ((this->Size[1] > 0) ? this->Size[1] : 300);
+    int width = ((this->GetActualSizeDirectly()[0] > 0) ? this->GetActualSizeDirectly()[0] : 300);
+    int height = ((this->GetActualSizeDirectly()[1] > 0) ? this->GetActualSizeDirectly()[1] : 300);
     this->CreateOffScreenWindow(width, height);
   }
 }
@@ -292,7 +291,7 @@ void vtkOSOpenGLRenderWindow::WindowRemap()
 // Specify the size of the rendering window.
 void vtkOSOpenGLRenderWindow::SetSize(int width, int height)
 {
-  if ((this->Size[0] != width) || (this->Size[1] != height))
+  if ((this->GetActualSizeDirectly()[0] != width) || (this->GetActualSizeDirectly()[1] != height))
   {
     this->Superclass::SetSize(width, height);
     if (!this->UseOffScreenBuffers)
@@ -316,7 +315,8 @@ void vtkOSOpenGLRenderWindow::MakeCurrent()
   if (this->Internal->OffScreenContextId)
   {
     if (OSMesaMakeCurrent(this->Internal->OffScreenContextId, this->Internal->OffScreenWindow,
-          GL_UNSIGNED_BYTE, this->Size[0], this->Size[1]) != GL_TRUE)
+          GL_UNSIGNED_BYTE, this->GetActualSizeDirectly()[0],
+          this->GetActualSizeDirectly()[1]) != GL_TRUE)
     {
       vtkWarningMacro("failed call to OSMesaMakeCurrent");
     }
@@ -352,7 +352,7 @@ vtkTypeBool vtkOSOpenGLRenderWindow::GetEventPending()
 }
 
 // Get the size of the screen in pixels
-int* vtkOSOpenGLRenderWindow::GetScreenSize()
+const int* vtkOSOpenGLRenderWindow::GetScreenSize()
 {
   this->ScreenSize[0] = 1280;
   this->ScreenSize[1] = 1024;

--- a/Rendering/OpenGL2/vtkOSOpenGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkOSOpenGLRenderWindow.h
@@ -88,7 +88,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenGL2/vtkOpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkOpenGLRenderWindow.cxx
@@ -1065,8 +1065,10 @@ void vtkOpenGLRenderWindow::Frame()
     vtkOpenGLFramebufferObject::Blit(srcExtents, srcExtents,
       (copiedColor ? 0 : GL_COLOR_BUFFER_BIT) | GL_DEPTH_BUFFER_BIT, GL_NEAREST);
 
-    this->GetState()->vtkglViewport(0, 0, this->Size[0], this->Size[1]);
-    this->GetState()->vtkglScissor(0, 0, this->Size[0], this->Size[1]);
+    this->GetState()->vtkglViewport(
+      0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
+    this->GetState()->vtkglScissor(
+      0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
     this->GetState()->PopFramebufferBindings();
 
     if (!this->UseOffScreenBuffers)
@@ -1088,11 +1090,11 @@ void vtkOpenGLRenderWindow::BlitDisplayFramebuffersToHardware()
   auto ostate = this->GetState();
   ostate->PushFramebufferBindings();
   this->DisplayFramebuffer->Bind(GL_READ_FRAMEBUFFER);
-  this->GetState()->vtkglViewport(0, 0, this->Size[0], this->Size[1]);
-  this->GetState()->vtkglScissor(0, 0, this->Size[0], this->Size[1]);
+  this->GetState()->vtkglViewport(0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
+  this->GetState()->vtkglScissor(0, 0, this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 
   // recall Blit upper right corner is exclusive of the range
-  const int srcExtents[4] = { 0, this->Size[0], 0, this->Size[1] };
+  const int srcExtents[4] = { 0, this->GetActualSizeDirectly()[0], 0, this->GetActualSizeDirectly()[1] };
 
   this->GetState()->vtkglBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 
@@ -1114,8 +1116,9 @@ void vtkOpenGLRenderWindow::BlitDisplayFramebuffersToHardware()
 
 void vtkOpenGLRenderWindow::BlitDisplayFramebuffer()
 {
-  this->BlitDisplayFramebuffer(0, 0, 0, this->Size[0], this->Size[1], 0, 0, this->Size[0],
-    this->Size[1], GL_COLOR_BUFFER_BIT, GL_NEAREST);
+  this->BlitDisplayFramebuffer(0, 0, 0, this->GetActualSizeDirectly()[0],
+    this->GetActualSizeDirectly()[1], 0, 0, this->GetActualSizeDirectly()[0],
+    this->GetActualSizeDirectly()[1], GL_COLOR_BUFFER_BIT, GL_NEAREST);
 }
 
 void vtkOpenGLRenderWindow::BlitDisplayFramebuffer(int right, int srcX, int srcY, int srcWidth,
@@ -1140,15 +1143,17 @@ void vtkOpenGLRenderWindow::BlitDisplayFramebuffer(int right, int srcX, int srcY
 
 void vtkOpenGLRenderWindow::BlitToRenderFramebuffer(bool includeDepth)
 {
-  this->BlitToRenderFramebuffer(0, 0, this->Size[0], this->Size[1], 0, 0, this->Size[0],
-    this->Size[1], GL_COLOR_BUFFER_BIT | (includeDepth ? GL_DEPTH_BUFFER_BIT : 0), GL_NEAREST);
+  this->BlitToRenderFramebuffer(0, 0, this->GetActualSizeDirectly()[0],
+    this->GetActualSizeDirectly()[1], 0, 0, this->GetActualSizeDirectly()[0],
+    this->GetActualSizeDirectly()[1],
+    GL_COLOR_BUFFER_BIT | (includeDepth ? GL_DEPTH_BUFFER_BIT : 0), GL_NEAREST);
 }
 
 void vtkOpenGLRenderWindow::BlitToRenderFramebuffer(int srcX, int srcY, int srcWidth, int srcHeight,
   int destX, int destY, int destWidth, int destHeight, int bufferMode, int interpolation)
 {
   // Ensure the offscreen framebuffer is created and updated to the right size
-  this->CreateFramebuffers(this->Size[0], this->Size[1]);
+  this->CreateFramebuffers(this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 
   // depending on what is current bound this can be tricky, especially between multisampled
   // buffers
@@ -1214,9 +1219,11 @@ void vtkOpenGLRenderWindow::Start()
     GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ONE, GL_ONE_MINUS_SRC_ALPHA);
 
   // creates or resizes the framebuffer
-  this->Size[0] = (this->Size[0] > 0 ? this->Size[0] : 300);
-  this->Size[1] = (this->Size[1] > 0 ? this->Size[1] : 300);
-  this->CreateFramebuffers(this->Size[0], this->Size[1]);
+  int newSize[2];
+  newSize[0] = (this->GetActualSizeDirectly()[0] > 0 ? this->GetActualSizeDirectly()[0] : 300);
+  newSize[1] = (this->GetActualSizeDirectly()[1] > 0 ? this->GetActualSizeDirectly()[1] : 300);
+  this->SetSizeNoEvent(newSize);
+  this->CreateFramebuffers(this->GetActualSizeDirectly()[0], this->GetActualSizeDirectly()[1]);
 
   // push and bind
   this->GetState()->PushFramebufferBindings();

--- a/Rendering/OpenGL2/vtkSDL2OpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkSDL2OpenGLRenderWindow.cxx
@@ -143,7 +143,7 @@ bool vtkSDL2OpenGLRenderWindow::SetSwapControl(int i)
 //------------------------------------------------------------------------------
 void vtkSDL2OpenGLRenderWindow::SetSize(int x, int y)
 {
-  if ((this->Size[0] != x) || (this->Size[1] != y))
+  if ((this->GetActualSizeDirectly()[0] != x) || (this->GetActualSizeDirectly()[1] != y))
   {
     this->Superclass::SetSize(x, y);
 
@@ -220,8 +220,8 @@ void vtkSDL2OpenGLRenderWindow::CreateAWindow()
 {
   int x = ((this->Position[0] >= 0) ? this->Position[0] : SDL_WINDOWPOS_UNDEFINED);
   int y = ((this->Position[1] >= 0) ? this->Position[1] : SDL_WINDOWPOS_UNDEFINED);
-  int height = ((this->Size[1] > 0) ? this->Size[1] : 300);
-  int width = ((this->Size[0] > 0) ? this->Size[0] : 300);
+  int height = ((this->GetActualSizeDirectly()[1] > 0) ? this->GetActualSizeDirectly()[1] : 300);
+  int width = ((this->GetActualSizeDirectly()[0] > 0) ? this->GetActualSizeDirectly()[0] : 300);
   this->SetSize(width, height);
 
 #ifdef __EMSCRIPTEN__
@@ -294,7 +294,7 @@ void vtkSDL2OpenGLRenderWindow::DestroyWindow()
 }
 
 // Get the current size of the window.
-int* vtkSDL2OpenGLRenderWindow::GetSize(void)
+const int* vtkSDL2OpenGLRenderWindow::GetSize(void)
 {
   // if we aren't mapped then just return the ivar
   if (this->WindowId && this->Mapped)
@@ -303,22 +303,20 @@ int* vtkSDL2OpenGLRenderWindow::GetSize(void)
     int h = 0;
 
     SDL_GetWindowSize(this->WindowId, &w, &h);
-    this->Size[0] = w;
-    this->Size[1] = h;
+    this->SetSizeNoEvent(w, h);
   }
 
   return this->vtkOpenGLRenderWindow::GetSize();
 }
 
 // Get the size of the whole screen.
-int* vtkSDL2OpenGLRenderWindow::GetScreenSize(void)
+const int* vtkSDL2OpenGLRenderWindow::GetScreenSize(void)
 {
   SDL_Rect rect;
   SDL_GetDisplayBounds(0, &rect);
-  this->Size[0] = rect.w;
-  this->Size[1] = rect.h;
+  this->SetSizeNoEvent(rect.w, rect.h);
 
-  return this->Size;
+  return this->GetActualSizeDirectly();
 }
 
 // Get the position in screen coordinates of the window.

--- a/Rendering/OpenGL2/vtkSDL2OpenGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkSDL2OpenGLRenderWindow.h
@@ -72,7 +72,7 @@ public:
   /**
    * Get the current size of the window in pixels.
    */
-  int* GetSize() VTK_SIZEHINT(2) override;
+  const int* GetSize() VTK_SIZEHINT(2) override;
 
   //@{
   /**
@@ -85,7 +85,7 @@ public:
   /**
    * Get the current size of the screen in pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position in screen coordinates of the window.

--- a/Rendering/OpenGL2/vtkWin32OpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkWin32OpenGLRenderWindow.cxx
@@ -367,7 +367,7 @@ void AdjustWindowRectForBorders(
 //------------------------------------------------------------------------------
 void vtkWin32OpenGLRenderWindow::SetSize(int width, int height)
 {
-  if ((this->Size[0] != width) || (this->Size[1] != height))
+  if ((this->GetActualSizeDirectly()[0] != width) || (this->GetActualSizeDirectly()[1] != height))
   {
     this->Superclass::SetSize(width, height);
 
@@ -963,8 +963,9 @@ void vtkWin32OpenGLRenderWindow::CreateAWindow()
 #endif
       int x = this->Position[0];
       int y = this->Position[1];
-      int height = ((this->Size[1] > 0) ? this->Size[1] : 300);
-      int width = ((this->Size[0] > 0) ? this->Size[0] : 300);
+      int height =
+        ((this->GetActualSizeDirectly()[1] > 0) ? this->GetActualSizeDirectly()[1] : 300);
+      int width = ((this->GetActualSizeDirectly()[0] > 0) ? this->GetActualSizeDirectly()[0] : 300);
 
       /* create window */
       if (this->ParentId)
@@ -1150,7 +1151,7 @@ void vtkWin32OpenGLRenderWindow::DestroyWindow()
 
 //------------------------------------------------------------------------------
 // Get the current size of the window.
-int* vtkWin32OpenGLRenderWindow::GetSize(void)
+const int* vtkWin32OpenGLRenderWindow::GetSize(void)
 {
   // if we aren't mapped then just call super
   if (this->WindowId && !this->UseOffScreenBuffers)
@@ -1160,13 +1161,11 @@ int* vtkWin32OpenGLRenderWindow::GetSize(void)
     // Find the current window size
     if (GetClientRect(this->WindowId, &rect))
     {
-      this->Size[0] = rect.right;
-      this->Size[1] = rect.bottom;
+      this->SetSizeNoEvent(rect.right, rect.bottom);
     }
     else
     {
-      this->Size[0] = 0;
-      this->Size[1] = 0;
+      this->SetSizeNoEvent(0, 0);
     }
   }
 
@@ -1175,7 +1174,7 @@ int* vtkWin32OpenGLRenderWindow::GetSize(void)
 
 //------------------------------------------------------------------------------
 // Get the size of the whole screen.
-int* vtkWin32OpenGLRenderWindow::GetScreenSize(void)
+const int* vtkWin32OpenGLRenderWindow::GetScreenSize(void)
 {
   HDC hDC = ::GetDC(nullptr);
   if (hDC)
@@ -1238,8 +1237,7 @@ void vtkWin32OpenGLRenderWindow::SetFullScreen(vtkTypeBool arg)
   {
     this->Position[0] = this->OldScreen[0];
     this->Position[1] = this->OldScreen[1];
-    this->Size[0] = this->OldScreen[2];
-    this->Size[1] = this->OldScreen[3];
+    this->SetSizeNoEvent(this->OldScreen[2], this->OldScreen[3]);
     this->Borders = this->OldScreen[4];
   }
   else
@@ -1294,8 +1292,7 @@ void vtkWin32OpenGLRenderWindow::PrefFullScreen()
   // use full screen
   this->Position[0] = 0;
   this->Position[1] = 0;
-  this->Size[0] = r.right - r.left;
-  this->Size[1] = r.bottom - r.top;
+  this->SetSizeNoEvent(r.right - r.left, r.bottom - r.top);
 }
 
 //------------------------------------------------------------------------------

--- a/Rendering/OpenGL2/vtkWin32OpenGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkWin32OpenGLRenderWindow.h
@@ -101,7 +101,7 @@ public:
    * Get the size (width and height) of the rendering window in
    * screen coordinates (in pixels).
    */
-  int* GetSize() VTK_SIZEHINT(2) override;
+  const int* GetSize() VTK_SIZEHINT(2) override;
 
   //@{
   /**
@@ -117,7 +117,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenGL2/vtkXOpenGLRenderWindow.cxx
+++ b/Rendering/OpenGL2/vtkXOpenGLRenderWindow.cxx
@@ -439,8 +439,8 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
 
   x = this->Position[0];
   y = this->Position[1];
-  width = ((this->Size[0] > 0) ? this->Size[0] : 300);
-  height = ((this->Size[1] > 0) ? this->Size[1] : 300);
+  width = ((this->GetActualSizeDirectly()[0] > 0) ? this->GetActualSizeDirectly()[0] : 300);
+  height = ((this->GetActualSizeDirectly()[1] > 0) ? this->GetActualSizeDirectly()[1] : 300);
 
   xsh.width = width;
   xsh.height = height;
@@ -536,8 +536,12 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
     // RESIZE THE WINDOW TO THE DESIRED SIZE
     vtkDebugMacro(<< "Resizing the xwindow\n");
     XResizeWindow(this->DisplayId, this->WindowId,
-      ((this->Size[0] > 0) ? static_cast<unsigned int>(this->Size[0]) : 300),
-      ((this->Size[1] > 0) ? static_cast<unsigned int>(this->Size[1]) : 300));
+      ((this->GetActualSizeDirectly()[0] > 0)
+          ? static_cast<unsigned int>(this->GetActualSizeDirectly()[0])
+          : 300),
+      ((this->GetActualSizeDirectly()[1] > 0)
+          ? static_cast<unsigned int>(this->GetActualSizeDirectly()[1])
+          : 300));
     XSync(this->DisplayId, False);
   }
 
@@ -675,8 +679,7 @@ void vtkXOpenGLRenderWindow::CreateAWindow()
   {
     XFree(v);
   }
-  this->Size[0] = width;
-  this->Size[1] = height;
+  this->SetSizeNoEvent(width, height);
 }
 
 void vtkXOpenGLRenderWindow::DestroyWindow()
@@ -856,8 +859,7 @@ void vtkXOpenGLRenderWindow::SetFullScreen(vtkTypeBool arg)
   {
     this->Position[0] = this->OldScreen[0];
     this->Position[1] = this->OldScreen[1];
-    this->Size[0] = this->OldScreen[2];
-    this->Size[1] = this->OldScreen[3];
+    this->SetSizeNoEvent(this->OldScreen[2], this->OldScreen[3]);
     this->Borders = this->OldScreen[4];
   }
   else
@@ -897,14 +899,11 @@ void vtkXOpenGLRenderWindow::PrefFullScreen()
 
   if (this->UseOffScreenBuffers)
   {
-    this->Size[0] = 1280;
-    this->Size[1] = 1024;
+    this->SetSizeNoEvent(1280, 1024);
   }
   else
   {
-    const int* size = this->GetScreenSize();
-    this->Size[0] = size[0];
-    this->Size[1] = size[1];
+    this->SetSizeNoEvent(this->GetScreenSize());
   }
 
   // don't show borders
@@ -942,7 +941,7 @@ void vtkXOpenGLRenderWindow::Start(void)
 // Specify the size of the rendering window.
 void vtkXOpenGLRenderWindow::SetSize(int width, int height)
 {
-  if ((this->Size[0] != width) || (this->Size[1] != height))
+  if ((this->GetActualSizeDirectly()[0] != width) || (this->GetActualSizeDirectly()[1] != height))
   {
     this->Superclass::SetSize(width, height);
 
@@ -972,7 +971,7 @@ void vtkXOpenGLRenderWindow::SetSize(int width, int height)
 
 void vtkXOpenGLRenderWindow::SetSizeNoXResize(int width, int height)
 {
-  if ((this->Size[0] != width) || (this->Size[1] != height))
+  if ((this->GetActualSizeDirectly()[0] != width) || (this->GetActualSizeDirectly()[1] != height))
   {
     this->Superclass::SetSize(width, height);
     this->Modified();
@@ -1182,7 +1181,7 @@ vtkTypeBool vtkXOpenGLRenderWindow::GetEventPending()
 }
 
 // Get the size of the screen in pixels
-int* vtkXOpenGLRenderWindow::GetScreenSize()
+const int* vtkXOpenGLRenderWindow::GetScreenSize()
 {
   // get the default display connection
   if (!this->DisplayId)
@@ -1566,8 +1565,7 @@ void vtkXOpenGLRenderWindow::Render()
     //  Find the current window size
     XGetWindowAttributes(this->DisplayId, this->WindowId, &attribs);
 
-    this->Size[0] = attribs.width;
-    this->Size[1] = attribs.height;
+    this->SetSizeNoEvent(attribs.width, attribs.height);
   }
 
   // Now do the superclass stuff

--- a/Rendering/OpenGL2/vtkXOpenGLRenderWindow.h
+++ b/Rendering/OpenGL2/vtkXOpenGLRenderWindow.h
@@ -166,7 +166,7 @@ public:
    * Get the current size of the screen in pixels.
    * An HDTV for example would be 1920 x 1080 pixels.
    */
-  int* GetScreenSize() VTK_SIZEHINT(2) override;
+  const int* GetScreenSize() VTK_SIZEHINT(2) override;
 
   /**
    * Get the position (x and y) of the rendering window in

--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.cxx
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.cxx
@@ -775,12 +775,11 @@ void vtkOpenVRRenderWindowInteractor::Initialize()
   }
 
   vtkOpenVRRenderWindow* ren = vtkOpenVRRenderWindow::SafeDownCast(this->RenderWindow);
-  int* size;
 
   this->Initialized = 1;
   // get the info we need from the RenderingWindow
 
-  size = ren->GetSize();
+  const int* size = ren->GetSize();
   ren->GetPosition();
   this->Enable();
   this->Size[0] = size[0];

--- a/Rendering/Parallel/Testing/Cxx/TestSimplePCompositeZPass.cxx
+++ b/Rendering/Parallel/Testing/Cxx/TestSimplePCompositeZPass.cxx
@@ -342,8 +342,7 @@ void MyProcess::Execute()
         renWin->Render();
         if (compositeZPass->IsSupported(static_cast<vtkOpenGLRenderWindow*>(renWin)))
         {
-          int* dims;
-          dims = renWin->GetSize();
+          const int* dims = renWin->GetSize();
           float* zBuffer = new float[dims[0] * dims[1]];
           renWin->GetZbufferData(0, 0, dims[0] - 1, dims[1] - 1, zBuffer);
 

--- a/Rendering/Parallel/vtkParallelRenderManager.cxx
+++ b/Rendering/Parallel/vtkParallelRenderManager.cxx
@@ -518,15 +518,8 @@ void vtkParallelRenderManager::StartRender()
   }
 
   // Make adjustments for window size.
-  int* tilesize;
-  if (this->ForceRenderWindowSize)
-  {
-    tilesize = this->ForcedRenderWindowSize;
-  }
-  else
-  {
-    tilesize = this->RenderWindow->GetActualSize();
-  }
+  const int* tilesize = this->ForceRenderWindowSize ? this->ForcedRenderWindowSize
+                                                    : this->RenderWindow->GetActualSize();
   int size[2];
   size[0] = tilesize[0];
   size[1] = tilesize[1];
@@ -1020,15 +1013,8 @@ void vtkParallelRenderManager::SetImageReductionFactorForUpdateRate(double desir
     return;
   }
 
-  int* size;
-  if (this->ForceRenderWindowSize)
-  {
-    size = this->ForcedRenderWindowSize;
-  }
-  else
-  {
-    size = this->RenderWindow->GetActualSize();
-  }
+  const int* size = this->ForceRenderWindowSize ? this->ForcedRenderWindowSize
+                                                : this->RenderWindow->GetActualSize();
   int numPixels = size[0] * size[1];
   int numReducedPixels =
     (int)(numPixels / (this->ImageReductionFactor * this->ImageReductionFactor));

--- a/Rendering/UI/vtkAndroidRenderWindowInteractor.cxx
+++ b/Rendering/UI/vtkAndroidRenderWindowInteractor.cxx
@@ -531,7 +531,6 @@ void vtkAndroidRenderWindowInteractor::Initialize()
   }
 
   vtkRenderWindow* ren;
-  int* size;
 
   this->Initialized = 1;
   // get the info we need from the RenderingWindow
@@ -573,7 +572,7 @@ void vtkAndroidRenderWindowInteractor::Initialize()
     }
   }
 
-  size = ren->GetSize();
+  const int* size = ren->GetSize();
   ren->GetPosition();
   this->Enable();
   this->Size[0] = size[0];

--- a/Rendering/UI/vtkSDL2RenderWindowInteractor.cxx
+++ b/Rendering/UI/vtkSDL2RenderWindowInteractor.cxx
@@ -266,7 +266,6 @@ void vtkSDL2RenderWindowInteractor::AddEventHandler()
 void vtkSDL2RenderWindowInteractor::Initialize()
 {
   vtkRenderWindow* ren;
-  int* size;
 
   // make sure we have a RenderWindow and camera
   if (!this->RenderWindow)
@@ -283,7 +282,7 @@ void vtkSDL2RenderWindowInteractor::Initialize()
   ren = this->RenderWindow;
   ren->Start();
   ren->End();
-  size = ren->GetSize();
+  const int* size = ren->GetSize();
   ren->GetPosition();
 
   this->Enable();

--- a/Rendering/UI/vtkWin32HardwareWindow.cxx
+++ b/Rendering/UI/vtkWin32HardwareWindow.cxx
@@ -148,8 +148,8 @@ void vtkWin32HardwareWindow::Create()
   {
     int x = this->Position[0];
     int y = this->Position[1];
-    int height = ((this->Size[1] > 0) ? this->Size[1] : 300);
-    int width = ((this->Size[0] > 0) ? this->Size[0] : 300);
+    int height = ((this->GetActualSizeDirectly()[1] > 0) ? this->GetActualSizeDirectly()[1] : 300);
+    int width = ((this->GetActualSizeDirectly()[0] > 0) ? this->GetActualSizeDirectly()[0] : 300);
 
     /* create window */
     if (this->ParentId)
@@ -216,7 +216,7 @@ void vtkWin32HardwareWindow::Destroy()
 void vtkWin32HardwareWindow::SetSize(int x, int y)
 {
   static bool resizing = false;
-  if ((this->Size[0] != x) || (this->Size[1] != y))
+  if ((this->GetActualSizeDirectly()[0] != x) || (this->GetActualSizeDirectly()[1] != y))
   {
     this->Superclass::SetSize(x, y);
 

--- a/Rendering/UI/vtkWin32RenderWindowInteractor.cxx
+++ b/Rendering/UI/vtkWin32RenderWindowInteractor.cxx
@@ -171,7 +171,6 @@ void vtkWin32RenderWindowInteractor::StartEventLoop()
 void vtkWin32RenderWindowInteractor::Initialize()
 {
   vtkRenderWindow* ren;
-  int* size;
 
   // make sure we have a RenderWindow and camera
   if (!this->RenderWindow)
@@ -188,7 +187,7 @@ void vtkWin32RenderWindowInteractor::Initialize()
   ren = this->RenderWindow;
   ren->Start();
   ren->End();
-  size = ren->GetSize();
+  const int* size = ren->GetSize();
   ren->GetPosition();
 
   this->WindowId = (HWND)(ren->GetGenericWindowId());
@@ -259,8 +258,7 @@ void vtkWin32RenderWindowInteractor::Enable()
     DragAcceptFiles(this->WindowId, TRUE);
 
     // in case the size of the window has changed while we were away
-    int* size;
-    size = ren->GetSize();
+    const int* size = ren->GetSize();
     this->Size[0] = size[0];
     this->Size[1] = size[1];
   }

--- a/Rendering/UI/vtkXRenderWindowInteractor.cxx
+++ b/Rendering/UI/vtkXRenderWindowInteractor.cxx
@@ -306,7 +306,6 @@ void vtkXRenderWindowInteractor::Initialize()
   }
 
   vtkRenderWindow* ren;
-  int* size;
 
   // make sure we have a RenderWindow and camera
   if (!this->RenderWindow)
@@ -329,9 +328,8 @@ void vtkXRenderWindowInteractor::Initialize()
 
   vtkXRenderWindowInteractorInternals::Instances.insert(this);
 
-  size = ren->GetActualSize();
-  size[0] = ((size[0] > 0) ? size[0] : 300);
-  size[1] = ((size[1] > 0) ? size[1] : 300);
+  const int* size = ren->GetActualSize();
+  ren->SetSizeNoEvent(((size[0] > 0) ? size[0] : 300), ((size[1] > 0) ? size[1] : 300));
   XSync(this->DisplayId, False);
 
   ren->Start();
@@ -343,9 +341,7 @@ void vtkXRenderWindowInteractor::Initialize()
   //  Find the current window size
   XGetWindowAttributes(this->DisplayId, this->WindowId, &attribs);
 
-  size[0] = attribs.width;
-  size[1] = attribs.height;
-  ren->SetSize(size[0], size[1]);
+  ren->SetSizeNoEvent(attribs.width, attribs.height);
 
   this->Enable();
   this->Size[0] = size[0];


### PR DESCRIPTION
These are the changes I am currently trying to get into the official VTK repository
https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8401

Adds caching to `vtkRenderer`/`vtkViewport`.
Updates `vtkWindow` to compute `TileSize` on change. This required changes to the `vtkWindow` interface to properly hide data instead of making it protected. I am not sure if this will be accepted by the VTK community, as it shifts the paradigm from "all data is protected" to a more modern "Avoid protected data (https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c133-avoid-protected-data)" in only one piece of one class. It also breaks the "nearly nothing is const"  by returning a const pointer instead of a non const one.