### PR TITLE
[Backport 8411] PERF: Increase efficiency in vtkRenderer and vtkViewport

### DIFF
--- a/Rendering/Core/vtkRenderer.cxx
+++ b/Rendering/Core/vtkRenderer.cxx
@@ -1424,7 +1424,6 @@ void vtkRenderer::WorldToView()
 // Convert world point coordinates to view coordinates.
 void vtkRenderer::WorldToView(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1434,8 +1433,7 @@ void vtkRenderer::WorldToView(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(mat,
-    this->ActiveCamera->GetCompositeProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1));
+  const auto& mat = this->GetCompositeProjectionTransformationMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1452,7 +1450,6 @@ void vtkRenderer::WorldToView(double& x, double& y, double& z)
 
 void vtkRenderer::WorldToPose(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1462,7 +1459,7 @@ void vtkRenderer::WorldToPose(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(mat, this->ActiveCamera->GetViewTransformMatrix());
+  const auto& mat = this->GetViewTransformMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1479,7 +1476,6 @@ void vtkRenderer::WorldToPose(double& x, double& y, double& z)
 
 void vtkRenderer::PoseToView(double& x, double& y, double& z)
 {
-  double mat[16];
   double view[4];
 
   // get the perspective transformation from the active camera
@@ -1489,8 +1485,7 @@ void vtkRenderer::PoseToView(double& x, double& y, double& z)
     x = y = z = 0.0;
     return;
   }
-  vtkMatrix4x4::DeepCopy(
-    mat, this->ActiveCamera->GetProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1));
+  const auto& mat = this->GetProjectionTransformationMatrix();
 
   view[0] = x * mat[0] + y * mat[1] + z * mat[2] + mat[3];
   view[1] = x * mat[4] + y * mat[5] + z * mat[6] + mat[7];
@@ -1518,10 +1513,10 @@ void vtkRenderer::PoseToWorld(double& x, double& y, double& z)
   }
 
   // get the perspective transformation from the active camera
-  vtkMatrix4x4* matrix = this->ActiveCamera->GetViewTransformMatrix();
+  const auto& matrix = this->GetViewTransformMatrix();
 
   // use the inverse matrix
-  vtkMatrix4x4::Invert(*matrix->Element, mat);
+  vtkMatrix4x4::Invert(matrix.data(), mat);
 
   // Transform point to world coordinates
   result[0] = x;
@@ -1553,13 +1548,8 @@ void vtkRenderer::ViewToPose(double& x, double& y, double& z)
     return;
   }
 
-  // get the perspective transformation from the active camera
-  vtkMatrix4x4* matrix =
-    this->ActiveCamera->GetProjectionTransformMatrix(this->GetTiledAspectRatio(), 0, 1);
-
-  // use the inverse matrix
-  vtkMatrix4x4::Invert(*matrix->Element, mat);
-
+  const auto& matrix = this->GetProjectionTransformationMatrix();
+  vtkMatrix4x4::Invert(matrix.data(), mat);
   // Transform point to world coordinates
   result[0] = x;
   result[1] = y;
@@ -1928,3 +1918,47 @@ int vtkRenderer::CaptureGL2PSSpecialProp(vtkProp* prop)
 }
 
 vtkCxxSetObjectMacro(vtkRenderer, GL2PSSpecialPropCollection, vtkPropCollection);
+
+const std::array<double, 16>& vtkRenderer::GetViewTransformMatrix()
+{
+  if (this->LastViewTransformCameraModified != this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(
+      this->ViewTransformMatrix.data(), this->ActiveCamera->GetViewTransformMatrix());
+
+    this->LastViewTransformCameraModified = this->ActiveCamera->GetMTime();
+  }
+  return this->ViewTransformMatrix;
+}
+
+const std::array<double, 16>& vtkRenderer::GetCompositeProjectionTransformationMatrix()
+{
+  const double tiledAspectRatio = this->GetTiledAspectRatio();
+  if (tiledAspectRatio != this->LastCompositeProjectionTransformationMatrixTiledAspectRatio ||
+    this->LastCompositeProjectionTransformationMatrixCameraModified !=
+      this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(this->CompositeProjectionTransformationMatrix.data(),
+      this->ActiveCamera->GetCompositeProjectionTransformMatrix(tiledAspectRatio, 0, 1));
+
+    this->LastCompositeProjectionTransformationMatrixTiledAspectRatio = tiledAspectRatio;
+    this->LastCompositeProjectionTransformationMatrixCameraModified =
+      this->ActiveCamera->GetMTime();
+  }
+  return this->CompositeProjectionTransformationMatrix;
+}
+
+const std::array<double, 16>& vtkRenderer::GetProjectionTransformationMatrix()
+{
+  const double tiledAspectRatio = this->GetTiledAspectRatio();
+  if (tiledAspectRatio != this->LastProjectionTransformationMatrixTiledAspectRatio ||
+    this->LastProjectionTransformationMatrixCameraModified != this->ActiveCamera->GetMTime())
+  {
+    vtkMatrix4x4::DeepCopy(this->ProjectionTransformationMatrix.data(),
+      this->ActiveCamera->GetProjectionTransformMatrix(tiledAspectRatio, 0, 1));
+
+    this->LastProjectionTransformationMatrixTiledAspectRatio = tiledAspectRatio;
+    this->LastProjectionTransformationMatrixCameraModified = this->ActiveCamera->GetMTime();
+  }
+  return this->ProjectionTransformationMatrix;
+}

--- a/Rendering/Core/vtkRenderer.h
+++ b/Rendering/Core/vtkRenderer.h
@@ -38,6 +38,8 @@
 #include "vtkActorCollection.h"  // Needed for access in inline members
 #include "vtkVolumeCollection.h" // Needed for access in inline members
 
+#include <array> // To store matrices
+
 class vtkFXAAOptions;
 class vtkRenderWindow;
 class vtkVolume;
@@ -926,6 +928,24 @@ protected:
   vtkPropCollection* GL2PSSpecialPropCollection;
 
   /**
+   * Gets the ActiveCamera CompositeProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  const std::array<double, 16>& GetCompositeProjectionTransformationMatrix();
+
+  /**
+   * Gets the ActiveCamera ProjectionTransformationMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  const std::array<double, 16>& GetProjectionTransformationMatrix();
+
+  /**
+   * Gets the ActiveCamera ViewTransformMatrix, only computing it if necessary.
+   * This function expects that this->ActiveCamera is not nullptr.
+   */
+  const std::array<double, 16>& GetViewTransformMatrix();
+
+  /**
    * Ask all props to update and draw any opaque and translucent
    * geometry. This includes both vtkActors and vtkVolumes
    * Returns the number of props that rendered geometry.
@@ -1078,6 +1098,46 @@ protected:
   double EnvironmentRight[3];
 
 private:
+  /**
+   * Cache of CompositeProjectionTransformationMatrix.
+   */
+  std::array<double, 16> CompositeProjectionTransformationMatrix;
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->CompositeProjectionTransformationMatrix.
+   */
+  double LastCompositeProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Modified time from the camera when this->CompositeProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastCompositeProjectionTransformationMatrixCameraModified;
+
+  /**
+   * Cache of ProjectionTransformationMatrix.
+   */
+  std::array<double, 16> ProjectionTransformationMatrix;
+
+  /**
+   * Tiled Aspect Ratio used to get the transform in this->ProjectionTransformationMatrix.
+   */
+  double LastProjectionTransformationMatrixTiledAspectRatio;
+
+  /**
+   * Modified time from the camera when this->ProjectionTransformationMatrix was set.
+   */
+  vtkMTimeType LastProjectionTransformationMatrixCameraModified;
+
+  /**
+   * Cache of ViewTransformMatrix.
+   */
+  std::array<double, 16> ViewTransformMatrix;
+
+  /**
+   * Modified time from the camera when this->ViewTransformMatrix was set.
+   */
+  vtkMTimeType LastViewTransformCameraModified;
+
   vtkRenderer(const vtkRenderer&) = delete;
   void operator=(const vtkRenderer&) = delete;
 };

--- a/Rendering/Core/vtkViewport.h
+++ b/Rendering/Core/vtkViewport.h
@@ -35,6 +35,8 @@
 #include "vtkObject.h"
 #include "vtkRenderingCoreModule.h" // For export macro
 
+#include <array> // To store matrices
+
 class vtkActor2DCollection;
 class vtkAssemblyPath;
 class vtkProp;
@@ -237,6 +239,15 @@ public:
     this->ViewToDisplay();
   }
 
+  /**
+   * Convert world point coordinates to display (or screen) coordinates.
+   */
+  inline void WorldToDisplay(double& x, double& y, double& z)
+  {
+    this->WorldToView(x, y, z);
+    this->ViewToDisplay(x, y, z);
+  }
+
   //@{
   /**
    * These methods map from one coordinate system to another.
@@ -261,6 +272,7 @@ public:
   virtual void WorldToPose(double&, double&, double&) {}
   virtual void ViewToWorld(double&, double&, double&) {}
   virtual void WorldToView(double&, double&, double&) {}
+  virtual void ViewToDisplay(double& x, double& y, double& z);
   //@}
 
   //@{
@@ -403,6 +415,10 @@ protected:
   double WorldPoint[4];
 
 private:
+  std::array<int, 2> LastComputeAspectSize;
+  std::array<double, 4> LastComputeAspectVPort;
+  std::array<double, 2> LastComputeAspectPixelAspect;
+
   vtkViewport(const vtkViewport&) = delete;
   void operator=(const vtkViewport&) = delete;
 };


### PR DESCRIPTION
Add overloads of vtkViewport::ViewToDisplay and
vtkViewport::WorldToDisplay that do not modify the vtkViewport, and,
therefore, will not trigger a modified event.
Caches of the camera's ProjectionTransformMatrix and
CompositeProjectionTransformMatrix in vtkRenderer are made and used to
increase efficiency of multiple calls that transform points to different
coordinate systems without updating the camera or aspect.
vtkRenderer now caches the camera ViewTransformMatrix and only updates
if the camera changes
vtkViewport::ComputeAspect the aspect is now only recomputed when the
window size, viewport, or pixel aspect changes