### PR TITLE
BUG: use alpha to calculate RGBA lighting

### DIFF
--- a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+++ b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
@@ -1579,7 +1579,6 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
   std::regex lightingRegex("__LIGHTING_COMPONENT__");
   shaderStr = std::regex_replace(shaderStr, lightingRegex, lightingComponent);
 
-  cerr << shaderStr;
   return shaderStr;
 }
 

--- a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+++ b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
@@ -1327,16 +1327,16 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
   }
   if (nDotL > 0.0)
   {
-    diffuse = nDotL * in_diffuse[component] *
+    diffuse = nDotL * in_diffuse[0] *
     in_lightDiffuseColor[0] * color.rgb;
     vDotR = max(vDotR, 0.0);
-    specular = pow(vDotR, in_shininess[component]) *
-                 in_specular[component] *
+    specular = pow(vDotR, in_shininess[0]) *
+                 in_specular[0] *
                  in_lightSpecularColor[0];
   }
   // For the headlight, ignore the light's ambient color
   // for now as it is causing the old mapper tests to fail
-  finalColor.xyz = in_ambient[component] * color.rgb +
+  finalColor.xyz = in_ambient[0] * color.rgb +
                    diffuse + specular;
 
         )***";
@@ -1404,7 +1404,7 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
       }
       if (rDotV > 0.0)
       {
-        float sf = attenuation * pow(rDotV, in_shininess[component]);
+        float sf = attenuation * pow(rDotV, in_shininess[0]);
         specular += (sf * in_lightSpecularColor[posNum]);
       }
     }
@@ -1430,15 +1430,15 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
       float rDotV = dot(-viewDirection, r);
       if (rDotV > 0.0)
       {
-        float sf = pow(rDotV, in_shininess[component]);
+        float sf = pow(rDotV, in_shininess[0]);
         specular += (sf * in_lightSpecularColor[dirNum]);
       }
     }
     ambient += in_lightAmbientColor[dirNum];
   }
-  finalColor.xyz = in_ambient[component] * ambient +
-                   in_diffuse[component] * diffuse * color.rgb +
-                   in_specular[component] * specular;
+  finalColor.xyz = in_ambient[0] * ambient +
+                   in_diffuse[0] * diffuse * color.rgb +
+                   in_specular[0] * specular;
 
       )***";
     }
@@ -1481,8 +1481,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
   tex_light = (in_inverseTextureDatasetMatrix[0] * in_inverseVolumeMatrix[0] * vec4(in_cameraPos, 1.0)).xyz;
   phase = phase_function(-1); // always angle of pi
   vol_shadow = volumeShadow(g_dataPos, tex_light, 1.0, component, in_volume[0], 0, label);
-  secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[component] * in_lightDiffuseColor[0];
-  secondary_contrib += in_ambient[component] * in_lightAmbientColor[0];
+  secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[0] * in_lightDiffuseColor[0];
+  secondary_contrib += in_ambient[0] * in_lightAmbientColor[0];
       )***";
     }
     else
@@ -1505,8 +1505,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
     attenuation *= max(0.0, sign(light_angle - cos(radians(in_lightConeAngle[posNum]))))
                      * pow(light_angle, in_lightExponent[posNum]);
     vol_shadow = volumeShadow(g_dataPos, tex_light, 1.0, component, in_volume[0], 0, label);
-    secondary_contrib += vol_shadow * phase * attenuation * color.rgb * in_diffuse[component] * in_lightDiffuseColor[posNum];
-    secondary_contrib += in_ambient[component] * in_lightAmbientColor[posNum];
+    secondary_contrib += vol_shadow * phase * attenuation * color.rgb * in_diffuse[0] * in_lightDiffuseColor[posNum];
+    secondary_contrib += in_ambient[0] * in_lightAmbientColor[posNum];
   }
       )***";
       }
@@ -1517,8 +1517,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
     tex_light = g_lightDirectionTex[dirNum];
     phase = phase_function(dot(normalize(-tex_light), view_tdir));
     vol_shadow = volumeShadow(g_dataPos, tex_light, 0.0, component, in_volume[0], 0, label);
-    secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[component] * in_lightDiffuseColor[dirNum];
-    secondary_contrib += in_ambient[component] * in_lightAmbientColor[dirNum];
+    secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[0] * in_lightDiffuseColor[dirNum];
+    secondary_contrib += in_ambient[0] * in_lightAmbientColor[dirNum];
   }
       )***";
     }
@@ -1676,14 +1676,14 @@ inline std::string ComputeLightingMultiDeclaration(vtkRenderer* vtkNotUsed(ren),
         \n     }\
         \n   if (nDotL > 0.0)\
         \n     {\
-        \n        diffuse = nDotL * in_diffuse[component] *\
+        \n        diffuse = nDotL * in_diffuse[0] *\
         \n                 in_lightDiffuseColor[0] * color.rgb;\
         \n        vDotR = max(vDotR, 0.0);\
-        \n        specular = pow(vDotR, in_shininess[component]) *\
-        \n                   in_specular[component] *\
+        \n        specular = pow(vDotR, in_shininess[0]) *\
+        \n                   in_specular[0] *\
         \n                   in_lightSpecularColor[0];\
         \n     }\
-        \n  finalColor.xyz = in_ambient[component] * color.rgb * in_lightAmbientColor[0] +\
+        \n  finalColor.xyz = in_ambient[0] * color.rgb * in_lightAmbientColor[0] +\
         \n                   diffuse + specular;\
         \n");
   }
@@ -1835,6 +1835,15 @@ inline std::string ComputeColorDeclaration(vtkRenderer* vtkNotUsed(ren),
       colorTableMap[0] + ",\
           \n                                        vec2(scalar.x, 0.0)).xyz,\
           \n                              opacity), 0, 0.0), 0.0, 1.0);\
+          \n  }");
+    return shaderStr;
+  }
+  else if (noOfComponents == 4 && !independentComponents)
+  {
+    shaderStr += std::string("\
+          \nvec4 computeColor(vec4 scalar, float opacity)\
+          \n  {\
+          \n  return clamp(computeLighting(vec4(scalar.xyz, opacity), 3, 0.0), 0.0, 1.0);\
           \n  }");
     return shaderStr;
   }

--- a/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
+++ b/Rendering/VolumeOpenGL2/vtkVolumeShaderComposer.h
@@ -30,6 +30,7 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <regex>
 
 namespace
 {
@@ -1258,6 +1259,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
 
   int const transferMode = volProperty->GetTransferFunctionMode();
 
+  std::string lightingComponent = independentComponents ? "component" : "0";
+
   bool const volumetricShadow = glMapper->GetVolumetricScatteringBlending() > 0.0;
   std::string volumetricCall = volumetricShadow
     ? "\n   vol_shadow = volumeShadow(g_dataPos, tex_light.xyz, 0.0, component, in_volume[0], "
@@ -1327,16 +1330,16 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
   }
   if (nDotL > 0.0)
   {
-    diffuse = nDotL * in_diffuse[0] *
+    diffuse = nDotL * in_diffuse[__LIGHTING_COMPONENT__] *
     in_lightDiffuseColor[0] * color.rgb;
     vDotR = max(vDotR, 0.0);
-    specular = pow(vDotR, in_shininess[0]) *
-                 in_specular[0] *
+    specular = pow(vDotR, in_shininess[__LIGHTING_COMPONENT__]) *
+                 in_specular[__LIGHTING_COMPONENT__] *
                  in_lightSpecularColor[0];
   }
   // For the headlight, ignore the light's ambient color
   // for now as it is causing the old mapper tests to fail
-  finalColor.xyz = in_ambient[0] * color.rgb +
+  finalColor.xyz = in_ambient[__LIGHTING_COMPONENT__] * color.rgb +
                    diffuse + specular;
 
         )***";
@@ -1404,7 +1407,7 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
       }
       if (rDotV > 0.0)
       {
-        float sf = attenuation * pow(rDotV, in_shininess[0]);
+        float sf = attenuation * pow(rDotV, in_shininess[__LIGHTING_COMPONENT__]);
         specular += (sf * in_lightSpecularColor[posNum]);
       }
     }
@@ -1430,15 +1433,15 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
       float rDotV = dot(-viewDirection, r);
       if (rDotV > 0.0)
       {
-        float sf = pow(rDotV, in_shininess[0]);
+        float sf = pow(rDotV, in_shininess[__LIGHTING_COMPONENT__]);
         specular += (sf * in_lightSpecularColor[dirNum]);
       }
     }
     ambient += in_lightAmbientColor[dirNum];
   }
-  finalColor.xyz = in_ambient[0] * ambient +
-                   in_diffuse[0] * diffuse * color.rgb +
-                   in_specular[0] * specular;
+  finalColor.xyz = in_ambient[__LIGHTING_COMPONENT__] * ambient +
+                   in_diffuse[__LIGHTING_COMPONENT__] * diffuse * color.rgb +
+                   in_specular[__LIGHTING_COMPONENT__] * specular;
 
       )***";
     }
@@ -1481,8 +1484,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
   tex_light = (in_inverseTextureDatasetMatrix[0] * in_inverseVolumeMatrix[0] * vec4(in_cameraPos, 1.0)).xyz;
   phase = phase_function(-1); // always angle of pi
   vol_shadow = volumeShadow(g_dataPos, tex_light, 1.0, component, in_volume[0], 0, label);
-  secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[0] * in_lightDiffuseColor[0];
-  secondary_contrib += in_ambient[0] * in_lightAmbientColor[0];
+  secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[__LIGHTING_COMPONENT__] * in_lightDiffuseColor[0];
+  secondary_contrib += in_ambient[__LIGHTING_COMPONENT__] * in_lightAmbientColor[0];
       )***";
     }
     else
@@ -1505,8 +1508,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
     attenuation *= max(0.0, sign(light_angle - cos(radians(in_lightConeAngle[posNum]))))
                      * pow(light_angle, in_lightExponent[posNum]);
     vol_shadow = volumeShadow(g_dataPos, tex_light, 1.0, component, in_volume[0], 0, label);
-    secondary_contrib += vol_shadow * phase * attenuation * color.rgb * in_diffuse[0] * in_lightDiffuseColor[posNum];
-    secondary_contrib += in_ambient[0] * in_lightAmbientColor[posNum];
+    secondary_contrib += vol_shadow * phase * attenuation * color.rgb * in_diffuse[__LIGHTING_COMPONENT__] * in_lightDiffuseColor[posNum];
+    secondary_contrib += in_ambient[__LIGHTING_COMPONENT__] * in_lightAmbientColor[posNum];
   }
       )***";
       }
@@ -1517,8 +1520,8 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
     tex_light = g_lightDirectionTex[dirNum];
     phase = phase_function(dot(normalize(-tex_light), view_tdir));
     vol_shadow = volumeShadow(g_dataPos, tex_light, 0.0, component, in_volume[0], 0, label);
-    secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[0] * in_lightDiffuseColor[dirNum];
-    secondary_contrib += in_ambient[0] * in_lightAmbientColor[dirNum];
+    secondary_contrib += vol_shadow * phase * color.rgb * in_diffuse[__LIGHTING_COMPONENT__] * in_lightDiffuseColor[dirNum];
+    secondary_contrib += in_ambient[__LIGHTING_COMPONENT__] * in_lightAmbientColor[dirNum];
   }
       )***";
     }
@@ -1573,6 +1576,10 @@ inline std::string ComputeLightingDeclaration(vtkRenderer* vtkNotUsed(ren), vtkV
       \n  return finalColor;\
       \n  }");
 
+  std::regex lightingRegex("__LIGHTING_COMPONENT__");
+  shaderStr = std::regex_replace(shaderStr, lightingRegex, lightingComponent);
+
+  cerr << shaderStr;
   return shaderStr;
 }
 
@@ -1676,14 +1683,14 @@ inline std::string ComputeLightingMultiDeclaration(vtkRenderer* vtkNotUsed(ren),
         \n     }\
         \n   if (nDotL > 0.0)\
         \n     {\
-        \n        diffuse = nDotL * in_diffuse[0] *\
+        \n        diffuse = nDotL * in_diffuse[__LIGHTING_COMPONENT__] *\
         \n                 in_lightDiffuseColor[0] * color.rgb;\
         \n        vDotR = max(vDotR, 0.0);\
-        \n        specular = pow(vDotR, in_shininess[0]) *\
-        \n                   in_specular[0] *\
+        \n        specular = pow(vDotR, in_shininess[__LIGHTING_COMPONENT__]) *\
+        \n                   in_specular[__LIGHTING_COMPONENT__] *\
         \n                   in_lightSpecularColor[0];\
         \n     }\
-        \n  finalColor.xyz = in_ambient[0] * color.rgb * in_lightAmbientColor[0] +\
+        \n  finalColor.xyz = in_ambient[__LIGHTING_COMPONENT__] * color.rgb * in_lightAmbientColor[0] +\
         \n                   diffuse + specular;\
         \n");
   }


### PR DESCRIPTION
Implements the feature and fixes discussed in this thread:

https://discourse.slicer.org/t/volume-rendering-colorized-with-segmentation/26689/6

Basically allows RGBA volumes to be shaded according to their alpha component so that something like a CT or microCT can define an rgb value at spatial regions, while getting opacity and gradient information from the alpha channel (e.g. the Hounsfield unit).

Also always uses the 0 channel for defining the lighting parameters. This part is WIP since it may be more appropriate to set the alpha channel lighting parameters in this scenario.  Currently, at least in 3D Slicer, only the 0 compnent's lighting parameters are being set, so they are being used here.