### PR TITLE
ENH: Add background masking mode to vtkImageMedian3D

### DIFF
--- a/Imaging/General/vtkImageMedian3D.h
+++ b/Imaging/General/vtkImageMedian3D.h
@@ -50,11 +50,33 @@ public:
   vtkGetMacro(NumberOfElements, int);
   ///@}
 
+  ///@{
+  /**
+   * Set/Get the background voxel value that is excluded from the median computation.
+   * \sa 
+   */
+  vtkSetMacro(BackgroundValue, double);
+  vtkGetMacro(BackgroundValue, double);
+  ///@}
+
+  ///@{
+  /**
+   * Exclude background voxels from the median computation.
+   * This is useful for dilating label volumes by half of the kernel size.
+   * \sa BackgroundValue
+   */
+  vtkSetMacro(IgnoreBackground, vtkTypeBool);
+  vtkGetMacro(IgnoreBackground, vtkTypeBool);
+  vtkBooleanMacro(IgnoreBackground, vtkTypeBool); 
+  ///@}
+
 protected:
   vtkImageMedian3D();
   ~vtkImageMedian3D() override;
 
   int NumberOfElements;
+  double BackgroundValue;
+  vtkTypeBool IgnoreBackground;
 
   void ThreadedRequestData(vtkInformation* request, vtkInformationVector** inputVector,
     vtkInformationVector* outputVector, vtkImageData*** inData, vtkImageData** outData,


### PR DESCRIPTION
Background voxels can be excluded from median filter computation. This is useful for dilating label volumes.

Required for https://discourse.slicer.org/t/vtk-multivolume-cinematic-volume-rendering/31981/5

Already submitted a PR for VTK gitlab (https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10588) but it would be nice if this could be merged along with https://github.com/Slicer/VTK/pull/43 so that we can have this new feature now. We can replace the commits by the official VTK versions when the VTK upstream PRs are merged.