### PR TITLE
[slicer-5.6-v9.2.20230607-1ff325c54-2]  Backport VR fix for correct volume rendering when HMD inside the volume

### DIFF
--- a/Rendering/OpenVR/vtkOpenVRRenderWindow.cxx
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindow.cxx
@@ -179,10 +179,13 @@ void vtkOpenVRRenderWindow::UpdateHMDMatrixPose()
   while ((ren = this->Renderers->GetNextRenderer(rit)))
   {
     vtkVRCamera* cam = vtkVRCamera::SafeDownCast(ren->GetActiveCamera());
-    cam->SetCameraFromDeviceToWorldMatrix(d2wMat, this->GetPhysicalScale());
-    if (ren->GetLightFollowCamera())
+    if (cam && cam->GetTrackHMD())
     {
-      ren->UpdateLightsGeometryToFollowCamera();
+      cam->SetCameraFromDeviceToWorldMatrix(d2wMat, this->GetPhysicalScale());
+      if (ren->GetLightFollowCamera())
+      {
+        ren->UpdateLightsGeometryToFollowCamera();
+      }
     }
   }
 }
@@ -211,29 +214,7 @@ void vtkOpenVRRenderWindow::SetMatrixFromOpenVRPose(
 //------------------------------------------------------------------------------
 void vtkOpenVRRenderWindow::Render()
 {
-  if (this->TrackHMD)
-  {
-    this->UpdateHMDMatrixPose();
-  }
-  else
-  {
-    // Retrieve OpenVR poses
-    vr::VRCompositor()->WaitGetPoses(
-      this->OpenVRTrackedDevicePoses, vr::k_unMaxTrackedDeviceCount, nullptr, 0);
-
-    // Store poses with generic type
-    for (uint32_t deviceIdx = 0; deviceIdx < vr::k_unMaxTrackedDeviceCount; ++deviceIdx)
-    {
-      if (this->OpenVRTrackedDevicePoses[deviceIdx].bPoseIsValid)
-      {
-        auto handle = this->GetDeviceHandleForOpenVRHandle(deviceIdx);
-        auto device = this->GetDeviceForOpenVRHandle(deviceIdx);
-        this->AddDeviceHandle(handle, device);
-        vtkMatrix4x4* tdPose = this->GetDeviceToPhysicalMatrixForDeviceHandle(handle);
-        this->SetMatrixFromOpenVRPose(tdPose, this->OpenVRTrackedDevicePoses[deviceIdx]);
-      }
-    }
-  }
+  this->UpdateHMDMatrixPose();
 
   this->Superclass::Render();
 }

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
@@ -177,10 +177,7 @@ void vtkOpenXRRenderWindow::Render()
     return;
   }
 
-  if (this->TrackHMD)
-  {
-    this->UpdateHMDMatrixPose();
-  }
+  this->UpdateHMDMatrixPose();
 
   if (xrManager.GetShouldRenderCurrentFrame())
   {
@@ -225,10 +222,13 @@ void vtkOpenXRRenderWindow::UpdateHMDMatrixPose()
   while ((ren = this->Renderers->GetNextRenderer(rit)))
   {
     vtkVRCamera* cam = vtkVRCamera::SafeDownCast(ren->GetActiveCamera());
-    cam->SetCameraFromDeviceToWorldMatrix(d2wMat, this->GetPhysicalScale());
-    if (ren->GetLightFollowCamera())
+    if (cam && cam->GetTrackHMD())
     {
-      ren->UpdateLightsGeometryToFollowCamera();
+      cam->SetCameraFromDeviceToWorldMatrix(d2wMat, this->GetPhysicalScale());
+      if (ren->GetLightFollowCamera())
+      {
+        ren->UpdateLightsGeometryToFollowCamera();
+      }
     }
   }
 }

--- a/Rendering/VR/vtkVRCamera.h
+++ b/Rendering/VR/vtkVRCamera.h
@@ -88,11 +88,23 @@ public:
   void SetCameraFromWorldToDeviceMatrix(vtkMatrix4x4* mat, double distance);
   void SetCameraFromDeviceToWorldMatrix(vtkMatrix4x4* mat, double distance);
 
+  ///@{
+  /**
+   * When enabled the camera will track the HMD position.
+   * On is the default.
+   *
+   * \sa vtkOpenVRRenderWindow::UpdateHMDMatrixPose, vtkOpenXRRenderWindow::UpdateHMDMatrixPose
+   */
+  vtkSetMacro(TrackHMD, bool);
+  vtkGetMacro(TrackHMD, bool);
+  ///@}
+
 protected:
   vtkVRCamera();
   ~vtkVRCamera() override;
 
   vtkNew<vtkMatrix4x4> TempMatrix4x4;
+  bool TrackHMD = true;
 
 private:
   vtkVRCamera(const vtkVRCamera&) = delete;

--- a/Rendering/VR/vtkVRHMDCamera.cxx
+++ b/Rendering/VR/vtkVRHMDCamera.cxx
@@ -17,6 +17,7 @@
 #include "vtkMatrix4x4.h"
 #include "vtkOpenGLError.h"
 #include "vtkOpenGLState.h"
+#include "vtkPerspectiveTransform.h"
 #include "vtkRenderer.h"
 #include "vtkTransform.h"
 #include "vtkVRRenderWindow.h"
@@ -157,6 +158,30 @@ void vtkVRHMDCamera::GetPhysicalToProjectionMatrix(vtkMatrix4x4*& physToProjecti
   else
   {
     physToProjectionMat = this->PhysicalToProjectionMatrixForRightEye;
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkVRHMDCamera::ComputeProjectionTransform(double aspect, double nearz, double farz)
+{
+  if (this->GetTrackHMD())
+  {
+    // Use the left and right matrices explicitly created
+    this->ProjectionTransform->Identity();
+    if (this->LeftEye)
+    {
+      this->ProjectionTransform->Concatenate(this->LeftEyeToProjectionMatrix);
+    }
+    else
+    {
+      this->ProjectionTransform->Concatenate(this->RightEyeToProjectionMatrix);
+    }
+  }
+  else
+  {
+    // TrackHMD is disabled for picking. In this case, we can use the default projection transform
+    // computation done by vtkCamera.
+    this->Superclass::ComputeProjectionTransform(aspect, nearz, farz);
   }
 }
 

--- a/Rendering/VR/vtkVRHMDCamera.h
+++ b/Rendering/VR/vtkVRHMDCamera.h
@@ -57,6 +57,11 @@ protected:
   virtual void UpdateWorldToEyeMatrices(vtkRenderer*) = 0;
   virtual void UpdateEyeToProjectionMatrices(vtkRenderer*) = 0;
 
+  /**
+   * These methods should only be used within vtkCamera.cxx.
+   */
+  void ComputeProjectionTransform(double aspect, double nearz, double farz) override;
+
   // all the matrices below are stored in VTK convention
   // as A = Mx where x is a column vector.
 

--- a/Rendering/VR/vtkVRHardwarePicker.cxx
+++ b/Rendering/VR/vtkVRHardwarePicker.cxx
@@ -14,13 +14,13 @@ PURPOSE.  See the above copyright notice for more information.
 =========================================================================*/
 #include "vtkVRHardwarePicker.h"
 
-#include "vtkCamera.h"
 #include "vtkCommand.h"
 #include "vtkHardwareSelector.h"
 #include "vtkObjectFactory.h"
 #include "vtkRenderer.h"
 #include "vtkSelection.h"
 #include "vtkTransform.h"
+#include "vtkVRCamera.h"
 #include "vtkVRRenderWindow.h"
 
 VTK_ABI_NAMESPACE_BEGIN
@@ -58,19 +58,24 @@ int vtkVRHardwarePicker::PickProp(
   sel->SetFieldAssociation(vtkDataObject::FIELD_ASSOCIATION_CELLS);
   sel->SetRenderer(renderer);
   sel->SetActorPassOnly(actorPassOnly);
-  vtkCamera* oldcam = renderer->GetActiveCamera();
-  renWin->SetTrackHMD(false);
+  vtkVRCamera* activeCam = vtkVRCamera::SafeDownCast(renderer->GetActiveCamera());
+  if (!activeCam)
+  {
+    return 0;
+  }
+  bool lastTrackHMD = activeCam->GetTrackHMD();
+  activeCam->SetTrackHMD(false);
 
   vtkNew<vtkTransform> tran;
   tran->RotateWXYZ(wxyz[0], wxyz[1], wxyz[2], wxyz[3]);
   double pin[4] = { 0.0, 0.0, -1.0, 1.0 };
   double dop[4];
   tran->MultiplyPoint(pin, dop);
-  double distance = oldcam->GetDistance();
-  oldcam->SetPosition(p0);
-  oldcam->SetFocalPoint(
+  double distance = activeCam->GetDistance();
+  activeCam->SetPosition(p0);
+  activeCam->SetFocalPoint(
     p0[0] + dop[0] * distance, p0[1] + dop[1] * distance, p0[2] + dop[2] * distance);
-  oldcam->OrthogonalizeViewUp();
+  activeCam->OrthogonalizeViewUp();
 
   const int* size = renderer->GetSize();
 
@@ -94,7 +99,7 @@ int vtkVRHardwarePicker::PickProp(
   // this->Selection = sel->Select();
   // sel->SetArea(0, 0, size[0]-1, size[1]-1);
 
-  renWin->SetTrackHMD(true);
+  activeCam->SetTrackHMD(lastTrackHMD);
 
   this->InvokeEvent(vtkCommand::EndPickEvent, this->Selection);
 

--- a/Rendering/VR/vtkVRRenderWindow.h
+++ b/Rendering/VR/vtkVRRenderWindow.h
@@ -51,8 +51,9 @@ PURPOSE.  See the above copyright notice for more information.
 #ifndef vtkVRRenderWindow_h
 #define vtkVRRenderWindow_h
 
-#include "vtkEventData.h" // for enums
-#include "vtkNew.h"       // for vtkNew
+#include "vtkDeprecation.h" // for deprecation
+#include "vtkEventData.h"   // for enums
+#include "vtkNew.h"         // for vtkNew
 #include "vtkOpenGLRenderWindow.h"
 #include "vtkRenderingVRModule.h" // For export macro
 #include "vtkSmartPointer.h"      // for vtkSmartPointer
@@ -352,7 +353,9 @@ public:
    * When on the camera will track the HMD position.
    * On is the default.
    */
+  VTK_DEPRECATED_IN_9_4_0("Please use vtkVRCamera::SetTrackHMD() instead.")
   vtkSetMacro(TrackHMD, bool);
+  VTK_DEPRECATED_IN_9_4_0("Please use vtkVRCamera::GetTrackHMD() instead.")
   vtkGetMacro(TrackHMD, bool);
   ///@}
 
@@ -403,6 +406,8 @@ protected:
   virtual void RenderFramebuffer(FramebufferDesc& framebufferDesc) = 0;
 
   bool VRInitialized = false;
+
+  VTK_DEPRECATED_IN_9_4_0("Please use vtkVRCamera::TrackHMD instead.")
   bool TrackHMD = true;
 
   // One per view (typically one per eye)


### PR DESCRIPTION
These changes correspond to the ones integrated in branch `slicer-v9.2.20230607-1ff325c54-2` through https://github.com/Slicer/VTK/pull/48

Fixes:
* https://github.com/KitwareMedical/SlicerVirtualReality/issues/125