### PR TITLE
[slicer-5.6-v9.2.20230607-1ff325c54-2]  Update VTK backporting VR, OpenVR and OpenXR improvements 

### DIFF
--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.cxx
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.cxx
@@ -365,7 +365,7 @@ void vtkOpenVRRenderWindowInteractor::DoOneEvent(vtkVRRenderWindow* renWin, vtkR
 
 //------------------------------------------------------------------------------
 void vtkOpenVRRenderWindowInteractor::AddAction(
-  std::string path, vtkCommand::EventIds eid, bool isAnalog)
+  const std::string& path, const vtkCommand::EventIds& eid, bool isAnalog)
 {
   // Path example: "/user/hand/right/input/trackpad"
   auto& am = this->ActionMap[path];
@@ -380,7 +380,7 @@ void vtkOpenVRRenderWindowInteractor::AddAction(
 
 //------------------------------------------------------------------------------
 void vtkOpenVRRenderWindowInteractor::AddAction(
-  std::string path, bool isAnalog, std::function<void(vtkEventData*)> func)
+  const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>& func)
 {
   // Path example: "/user/hand/right/input/trackpad"
   auto& am = this->ActionMap[path];

--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
@@ -50,8 +50,8 @@ public:
   /**
    * Assign an event or std::function to an event path.
    */
-  void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog);
-  void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>);
+  void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog) override;
+  void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>) override;
   ///@}
 
 protected:

--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
@@ -50,8 +50,8 @@ public:
   /**
    * Assign an event or std::function to an event path.
    */
-  void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog);
-  void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>);
+  void AddAction(const std::string& path, const vtkCommand::EventIds&, bool isAnalog);
+  void AddAction(const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>&);
   ///@}
 
 protected:

--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
@@ -50,8 +50,9 @@ public:
   /**
    * Assign an event or std::function to an event path.
    */
-  void AddAction(const std::string& path, const vtkCommand::EventIds&, bool isAnalog);
-  void AddAction(const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>&);
+  void AddAction(const std::string& path, const vtkCommand::EventIds&, bool isAnalog) override;
+  void AddAction(
+    const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>&) override;
   ///@}
 
 protected:

--- a/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
+++ b/Rendering/OpenVR/vtkOpenVRRenderWindowInteractor.h
@@ -50,8 +50,8 @@ public:
   /**
    * Assign an event or std::function to an event path.
    */
-  void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog) override;
-  void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>) override;
+  void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog);
+  void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>);
   ///@}
 
 protected:

--- a/Rendering/OpenXR/CMakeLists.txt
+++ b/Rendering/OpenXR/CMakeLists.txt
@@ -41,6 +41,7 @@ set(openxr_input_files
   vtk_openxr_binding_hp_mixed_reality.json
   vtk_openxr_binding_knuckles.json
   vtk_openxr_binding_microsoft_hand_interaction.json
+  vtk_openxr_binding_oculus_touch_controller.json
 )
 
 foreach(inputfile ${openxr_input_files})

--- a/Rendering/OpenXR/vtkOpenXRManager.cxx
+++ b/Rendering/OpenXR/vtkOpenXRManager.cxx
@@ -268,6 +268,10 @@ bool vtkOpenXRManager::BeginSession()
 //------------------------------------------------------------------------------
 bool vtkOpenXRManager::WaitAndBeginFrame()
 {
+  // Proactively reset the flag to avoid any attempted rendering in case
+  // the function exits prematurely.
+  this->ShouldRenderCurrentFrame = false;
+
   VTK_CHECK_NULL_XRHANDLE(this->Session, "vtkOpenXRManager::WaitAndBeginFrame, Session");
 
   // Wait frame

--- a/Rendering/OpenXR/vtkOpenXRManager.h
+++ b/Rendering/OpenXR/vtkOpenXRManager.h
@@ -606,8 +606,11 @@ protected:
   XrTime PredictedDisplayTime;
 
   bool SessionRunning = false;
-  // After each WaitAndBeginFrame, the OpenXR runtime may inform us that
-  // the current frame should not be rendered. Store it to avoid a render
+  // Following each WaitAndBeginFrame operation, the OpenXR runtime may indicate
+  // whether the current frame should be rendered using the `XrFrameState.shouldRender`
+  // property. We store this information to optimize rendering and prevent unnecessary
+  // render calls. For further details, refer to: 
+  // https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrFrameState.html
   bool ShouldRenderCurrentFrame = false;
   // If true, the function UpdateActionData will store
   // pose velocities for pose actions

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
@@ -184,10 +184,6 @@ void vtkOpenXRRenderWindow::Render()
     // Start rendering
     this->Superclass::Render();
   }
-  else
-  {
-    vtkWarningMacro(<< "Not rendered");
-  }
 
   xrManager.EndFrame();
 }

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
@@ -477,6 +477,13 @@ void vtkOpenXRRenderWindowInteractor::HandleVector2fAction(
 
 //------------------------------------------------------------------------------
 void vtkOpenXRRenderWindowInteractor::AddAction(
+  const std::string& path, const vtkCommand::EventIds& eid, bool vtkNotUsed(isAnalog))
+{
+  this->AddAction(path, eid);
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXRRenderWindowInteractor::AddAction(
   const std::string& path, const vtkCommand::EventIds& eid)
 {
   if (this->MapActionStruct_Name.count(path) == 0)
@@ -488,6 +495,13 @@ void vtkOpenXRRenderWindowInteractor::AddAction(
   auto* am = this->MapActionStruct_Name[path];
   am->EventId = eid;
   am->UseFunction = false;
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXRRenderWindowInteractor::AddAction(const std::string& path, bool vtkNotUsed(isAnalog),
+  const std::function<void(vtkEventData*)>& func)
+{
+  this->AddAction(path, func);
 }
 
 //------------------------------------------------------------------------------

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
@@ -62,7 +62,20 @@ public:
   void AddAction(const std::string& path, const vtkCommand::EventIds&);
   void AddAction(const std::string& path, const std::function<void(vtkEventData*)>&);
   ///@}
-  // add an event action
+
+  ///@{
+  /**
+   * Assign an event or std::function to an event path
+   *
+   * \note
+   * The \a isAnalog parameter is ignored; these signatures are intended to satisfy
+   * the base class interface and are functionally equivalent to calling the AddAction()
+   * function without it.
+   */
+  void AddAction(const std::string& path, const vtkCommand::EventIds&, bool isAnalog) override;
+  void AddAction(
+    const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>&) override;
+  ///@}
 
   void ConvertOpenXRPoseToWorldCoordinates(const XrPosef& xrPose,
     double pos[3],   // Output world position

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
@@ -59,8 +59,8 @@ public:
    * Assign an event or std::function to an event path.
    * Called by the interactor style for specific actions
    */
-  void AddAction(const std::string& path, const vtkCommand::EventIds&);
-  void AddAction(const std::string& path, const std::function<void(vtkEventData*)>&);
+  void AddAction(const std::string& path, const vtkCommand::EventIds&) override;
+  void AddAction(const std::string& path, const std::function<void(vtkEventData*)>&) override;
   ///@}
   // add an event action
 

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.h
@@ -59,8 +59,8 @@ public:
    * Assign an event or std::function to an event path.
    * Called by the interactor style for specific actions
    */
-  void AddAction(const std::string& path, const vtkCommand::EventIds&) override;
-  void AddAction(const std::string& path, const std::function<void(vtkEventData*)>&) override;
+  void AddAction(const std::string& path, const vtkCommand::EventIds&);
+  void AddAction(const std::string& path, const std::function<void(vtkEventData*)>&);
   ///@}
   // add an event action
 

--- a/Rendering/OpenXR/vtk_openxr_actions.json
+++ b/Rendering/OpenXR/vtk_openxr_actions.json
@@ -59,6 +59,10 @@
       "controller_type": "vive_controller"
     },
     {
+      "binding_url": "vtk_openxr_binding_oculus_touch_controller.json",
+      "controller_type": "oculus_touch"
+    },
+    {
       "binding_url": "vtk_openxr_binding_hp_mixed_reality.json",
       "controller_type": "mixed_reality"
     },

--- a/Rendering/OpenXR/vtk_openxr_binding_oculus_touch_controller.json
+++ b/Rendering/OpenXR/vtk_openxr_binding_oculus_touch_controller.json
@@ -1,0 +1,81 @@
+{
+  "interaction_profile": "/interaction_profiles/oculus/touch_controller",
+
+  "bindings": {
+    "vtk-actions": {
+      "sources": [
+        {
+          "inputs": {
+            "pose": {
+              "output": "handpose"
+            }
+          },
+          "path": "/user/hand/left/input/aim"
+        },
+        {
+          "inputs": {
+            "pose": {
+              "output": "handpose"
+            }
+          },
+          "path": "/user/hand/right/input/aim"
+        },
+        {
+          "inputs": {
+            "touch": {
+              "output": "startmovement"
+            },
+            "position": {
+              "output": "movement"
+            }
+          },
+          "path": "/user/hand/right/input/thumbstick"
+        },
+        {
+          "inputs": {},
+          "path": "/user/hand/left/input/menu"
+        },
+        {
+          "inputs": {
+            "click": {
+              "output": "showmenu"
+            }
+          },
+          "path": "/user/hand/right/input/b"
+        },
+        {
+          "inputs": {
+            "click": {
+              "output": "forwardthickcrop"
+            }
+          },
+          "path": "/user/hand/left/input/y"
+        },
+        {
+          "inputs": {
+            "click": {
+              "output": "triggeraction"
+            }
+          },
+          "path": "/user/hand/right/input/a"
+        },
+        {
+          "inputs": {
+            "click": {
+              "output": "nextcamerapose"
+            }
+          },
+          "path": "/user/hand/left/input/menu"
+        },
+        {
+          "inputs": {
+            "click": {
+              "output": "backthickcrop"
+            }
+          },
+          "path": "/user/hand/left/input/x"
+        }
+      ]
+    }
+  }
+}

--- a/Rendering/VR/vtkVRInteractorStyle.cxx
+++ b/Rendering/VR/vtkVRInteractorStyle.cxx
@@ -172,14 +172,11 @@ void vtkVRInteractorStyle::OnSelect3D(vtkEventData* edata)
   int y = this->Interactor->GetEventPosition()[1];
   this->FindPokedRenderer(x, y);
 
-  decltype(this->InputMap)::key_type key(vtkCommand::Select3DEvent, bd->GetAction());
-  auto it = this->InputMap.find(key);
-  if (it == this->InputMap.end())
+  int state = this->GetMappedAction(vtkCommand::Select3DEvent, bd->GetAction());
+  if (state < VTKIS_NONE)
   {
     return;
   }
-
-  int state = it->second;
 
   // if grab mode then convert event data into where the ray is intersecting geometry
   switch (bd->GetAction())
@@ -974,16 +971,12 @@ void vtkVRInteractorStyle::MapInputToAction(
     return;
   }
 
-  decltype(this->InputMap)::key_type key(eid, action);
-  auto it = this->InputMap.find(key);
-  if (it != this->InputMap.end())
+  if (this->GetMappedAction(eid, action) == state)
   {
-    if (it->second == state)
-    {
-      return;
-    }
+    return;
   }
 
+  decltype(this->InputMap)::key_type key(eid, action);
   this->InputMap[key] = state;
 
   this->Modified();
@@ -994,6 +987,21 @@ void vtkVRInteractorStyle::MapInputToAction(vtkCommand::EventIds eid, int state)
 {
   this->MapInputToAction(eid, vtkEventDataAction::Press, state);
   this->MapInputToAction(eid, vtkEventDataAction::Release, state);
+}
+
+//----------------------------------------------------------------------------
+int vtkVRInteractorStyle::GetMappedAction(vtkCommand::EventIds eid, vtkEventDataAction action)
+{
+  decltype(this->InputMap)::key_type key(eid, action);
+
+  auto it = this->InputMap.find(key);
+  if (it != this->InputMap.end())
+  {
+    return it->second;
+  }
+  // Since VTKIS_*STATE* are expected to be >= VTKIS_NONE with VTKIS_NONE == 0,
+  // return -1 if no mapping is found.
+  return -1;
 }
 
 //------------------------------------------------------------------------------

--- a/Rendering/VR/vtkVRInteractorStyle.cxx
+++ b/Rendering/VR/vtkVRInteractorStyle.cxx
@@ -1114,6 +1114,17 @@ void vtkVRInteractorStyle::EndAction(int state, vtkEventDataDevice3D* edata)
 }
 
 //------------------------------------------------------------------------------
+void vtkVRInteractorStyle::SetInteractionState(vtkEventDataDevice device, int state)
+{
+  int deviceIndex = static_cast<int>(device);
+  if (deviceIndex < 0 || deviceIndex >= vtkEventDataNumberOfDevices || state < VTKIS_NONE)
+  {
+    return;
+  }
+  this->InteractionState[static_cast<int>(device)] = state;
+}
+
+//------------------------------------------------------------------------------
 void vtkVRInteractorStyle::AddTooltipForInput(
   vtkEventDataDevice device, vtkEventDataDeviceInput input, const std::string& text)
 {

--- a/Rendering/VR/vtkVRInteractorStyle.h
+++ b/Rendering/VR/vtkVRInteractorStyle.h
@@ -129,6 +129,8 @@ public:
    */
   void MapInputToAction(vtkCommand::EventIds eid, int state);
   void MapInputToAction(vtkCommand::EventIds eid, vtkEventDataAction action, int state);
+  int GetMappedAction(
+    vtkCommand::EventIds eid, vtkEventDataAction action = vtkEventDataAction::Press);
   ///@}
 
   /**

--- a/Rendering/VR/vtkVRInteractorStyle.h
+++ b/Rendering/VR/vtkVRInteractorStyle.h
@@ -187,6 +187,13 @@ public:
    */
   int GetInteractionState(vtkEventDataDevice device)
   {
+    int deviceIndex = static_cast<int>(device);
+    if (deviceIndex < 0 || deviceIndex >= vtkEventDataNumberOfDevices)
+    {
+      // Since VTKIS_*STATE* are expected to be >= VTKIS_NONE with VTKIS_NONE == 0,
+      // return -1 if device is invalid.
+      return -1;
+    }
     return this->InteractionState[static_cast<int>(device)];
   }
 

--- a/Rendering/VR/vtkVRInteractorStyle.h
+++ b/Rendering/VR/vtkVRInteractorStyle.h
@@ -182,11 +182,22 @@ public:
 
   /**
    * Return interaction state for the specified device (dolly, pick, none, etc...).
+   *
+   * \sa SetInteractionState()
    */
   int GetInteractionState(vtkEventDataDevice device)
   {
     return this->InteractionState[static_cast<int>(device)];
   }
+
+  /**
+   * Set interaction state for the specified device (dolly, pick, none, etc...).
+   *
+   * This method **does not** call `this->Modified()`.
+   *
+   * \sa GetInteractionState()
+   */
+  void SetInteractionState(vtkEventDataDevice device, int state);
 
   ///@{
   /**

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -356,7 +356,7 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
       this->DeviceInputDownCount[static_cast<int>(vtkEventDataDevice::RightController)])
     {
       // The gesture is still unknown
-      this->CurrentGesture = vtkCommand::StartEvent;
+      this->SetCurrentGesture(vtkCommand::StartEvent);
     }
   }
 
@@ -377,7 +377,7 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
     {
       this->EndRotateEvent();
     }
-    this->CurrentGesture = vtkCommand::NoEvent;
+    this->SetCurrentGesture(vtkCommand::NoEvent);
 
     return;
   }
@@ -393,7 +393,7 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
   if (this->DeviceInputDownCount[lhand] > 1 || this->DeviceInputDownCount[lhand] == 0 ||
     this->DeviceInputDownCount[rhand] > 1 || this->DeviceInputDownCount[rhand] == 0)
   {
-    this->CurrentGesture = vtkCommand::NoEvent;
+    this->SetCurrentGesture(vtkCommand::NoEvent);
     return;
   }
 
@@ -463,19 +463,19 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
 
       if (pinchDistance > thresh && pinchDistance > panDistance && pinchDistance > rotateDistance)
       {
-        this->CurrentGesture = vtkCommand::PinchEvent;
+        this->SetCurrentGesture(vtkCommand::PinchEvent);
         this->Scale = 1.0;
         this->StartPinchEvent();
       }
       else if (rotateDistance > thresh && rotateDistance > panDistance)
       {
-        this->CurrentGesture = vtkCommand::RotateEvent;
+        this->SetCurrentGesture(vtkCommand::RotateEvent);
         this->Rotation = 0.0;
         this->StartRotateEvent();
       }
       else if (panDistance > thresh)
       {
-        this->CurrentGesture = vtkCommand::PanEvent;
+        this->SetCurrentGesture(vtkCommand::PanEvent);
         this->Translation3D[0] = 0.0;
         this->Translation3D[1] = 0.0;
         this->Translation3D[2] = 0.0;
@@ -522,5 +522,11 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
 vtkCommand::EventIds vtkVRRenderWindowInteractor::GetCurrentGesture() const
 {
   return this->CurrentGesture;
+}
+
+//------------------------------------------------------------------------------
+void vtkVRRenderWindowInteractor::SetCurrentGesture(vtkCommand::EventIds eid)
+{
+  this->CurrentGesture = eid;
 }
 VTK_ABI_NAMESPACE_END

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -352,8 +352,8 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
     renWin->GetPhysicalToWorldMatrix(this->StartingPhysicalToWorldMatrix);
 
     // Both controllers have a button down, start complex gesture handling
-    if (this->DeviceInputDownCount[static_cast<int>(vtkEventDataDevice::LeftController)] &&
-      this->DeviceInputDownCount[static_cast<int>(vtkEventDataDevice::RightController)])
+    if (this->GetDeviceInputDownCount(vtkEventDataDevice::LeftController) &&
+      this->GetDeviceInputDownCount(vtkEventDataDevice::RightController))
     {
       // The gesture is still unknown
       this->SetCurrentGesture(vtkCommand::StartEvent);
@@ -387,11 +387,11 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
 void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
 {
   // Recognize gesture only if one button is pressed per controller
-  int lhand = static_cast<int>(vtkEventDataDevice::LeftController);
-  int rhand = static_cast<int>(vtkEventDataDevice::RightController);
+  vtkEventDataDevice lhand = vtkEventDataDevice::LeftController;
+  vtkEventDataDevice rhand = vtkEventDataDevice::RightController;
 
-  if (this->DeviceInputDownCount[lhand] > 1 || this->DeviceInputDownCount[lhand] == 0 ||
-    this->DeviceInputDownCount[rhand] > 1 || this->DeviceInputDownCount[rhand] == 0)
+  if (this->GetDeviceInputDownCount(lhand) > 1 || this->GetDeviceInputDownCount(lhand) == 0 ||
+    this->GetDeviceInputDownCount(rhand) > 1 || this->GetDeviceInputDownCount(rhand) == 0)
   {
     this->SetCurrentGesture(vtkCommand::NoEvent);
     return;
@@ -399,11 +399,11 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
 
   double* posVals[2];
   double* startVals[2];
-  posVals[0] = this->PhysicalEventPositions[lhand];
-  posVals[1] = this->PhysicalEventPositions[rhand];
+  posVals[0] = this->PhysicalEventPositions[static_cast<int>(lhand)];
+  posVals[1] = this->PhysicalEventPositions[static_cast<int>(rhand)];
 
-  startVals[0] = this->StartingPhysicalEventPositions[lhand];
-  startVals[1] = this->StartingPhysicalEventPositions[rhand];
+  startVals[0] = this->StartingPhysicalEventPositions[static_cast<int>(lhand)];
+  startVals[1] = this->StartingPhysicalEventPositions[static_cast<int>(rhand)];
 
   // The meat of the algorithm.
   // On move events we analyze them to determine what type
@@ -516,6 +516,16 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
       this->PanEvent();
     }
   }
+}
+
+//------------------------------------------------------------------------------
+int vtkVRRenderWindowInteractor::GetDeviceInputDownCount(vtkEventDataDevice device) const
+{
+  if (device != vtkEventDataDevice::LeftController && device != vtkEventDataDevice::RightController)
+  {
+    return 0;
+  }
+  return this->DeviceInputDownCount[static_cast<int>(device)];
 }
 
 //------------------------------------------------------------------------------

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -339,7 +339,7 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
   this->PointerIndex = static_cast<int>(edata->GetDevice());
   if (edata->GetAction() == vtkEventDataAction::Press)
   {
-    this->DeviceInputDownCount[this->PointerIndex] = 1;
+    this->SetDeviceInputDownCount(edata->GetDevice(), 1);
 
     this->StartingPhysicalEventPositions[this->PointerIndex][0] =
       this->PhysicalEventPositions[this->PointerIndex][0];
@@ -363,7 +363,7 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
   // End the gesture if needed
   if (edata->GetAction() == vtkEventDataAction::Release)
   {
-    this->DeviceInputDownCount[this->PointerIndex] = 0;
+    this->SetDeviceInputDownCount(edata->GetDevice(), 0);
 
     if (this->GetCurrentGesture() == vtkCommand::PinchEvent)
     {
@@ -526,6 +526,16 @@ int vtkVRRenderWindowInteractor::GetDeviceInputDownCount(vtkEventDataDevice devi
     return 0;
   }
   return this->DeviceInputDownCount[static_cast<int>(device)];
+}
+
+//------------------------------------------------------------------------------
+void vtkVRRenderWindowInteractor::SetDeviceInputDownCount(vtkEventDataDevice device, int count)
+{
+  if (device != vtkEventDataDevice::LeftController && device != vtkEventDataDevice::RightController)
+  {
+    return;
+  }
+  this->DeviceInputDownCount[static_cast<int>(device)] = count;
 }
 
 //------------------------------------------------------------------------------

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -365,15 +365,15 @@ void vtkVRRenderWindowInteractor::HandleComplexGestureEvents(vtkEventData* ed)
   {
     this->DeviceInputDownCount[this->PointerIndex] = 0;
 
-    if (this->CurrentGesture == vtkCommand::PinchEvent)
+    if (this->GetCurrentGesture() == vtkCommand::PinchEvent)
     {
       this->EndPinchEvent();
     }
-    if (this->CurrentGesture == vtkCommand::PanEvent)
+    if (this->GetCurrentGesture() == vtkCommand::PanEvent)
     {
       this->EndPanEvent();
     }
-    if (this->CurrentGesture == vtkCommand::RotateEvent)
+    if (this->GetCurrentGesture() == vtkCommand::RotateEvent)
     {
       this->EndRotateEvent();
     }
@@ -408,7 +408,7 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
   // The meat of the algorithm.
   // On move events we analyze them to determine what type
   // of movement it is and then deal with it.
-  if (this->CurrentGesture != vtkCommand::NoEvent)
+  if (this->GetCurrentGesture() != vtkCommand::NoEvent)
   {
     // Calculate the distances
     double originalDistance = sqrt(vtkMath::Distance2BetweenPoints(startVals[0], startVals[1]));
@@ -448,7 +448,7 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
     double angleDeviation = newAngle - originalAngle;
 
     // Do we know what gesture we are doing yet? If not, see if we can figure it out
-    if (this->CurrentGesture == vtkCommand::StartEvent)
+    if (this->GetCurrentGesture() == vtkCommand::StartEvent)
     {
       // Pinch is a move to/from the center point.
       // Rotate is a move along the circumference.
@@ -484,17 +484,17 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
     }
 
     // If we have found a specific type of movement then handle it
-    if (this->CurrentGesture == vtkCommand::RotateEvent)
+    if (this->GetCurrentGesture() == vtkCommand::RotateEvent)
     {
       this->SetRotation(angleDeviation);
       this->RotateEvent();
     }
-    if (this->CurrentGesture == vtkCommand::PinchEvent)
+    if (this->GetCurrentGesture() == vtkCommand::PinchEvent)
     {
       this->SetScale(newDistance / originalDistance);
       this->PinchEvent();
     }
-    if (this->CurrentGesture == vtkCommand::PanEvent)
+    if (this->GetCurrentGesture() == vtkCommand::PanEvent)
     {
       // HMD to world axes
       vtkVRRenderWindow* win = vtkVRRenderWindow::SafeDownCast(this->RenderWindow);
@@ -516,5 +516,11 @@ void vtkVRRenderWindowInteractor::RecognizeComplexGesture(vtkEventDataDevice3D*)
       this->PanEvent();
     }
   }
+}
+
+//------------------------------------------------------------------------------
+vtkCommand::EventIds vtkVRRenderWindowInteractor::GetCurrentGesture() const
+{
+  return this->CurrentGesture;
 }
 VTK_ABI_NAMESPACE_END

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -297,6 +297,17 @@ void vtkVRRenderWindowInteractor::GetStartingPhysicalToWorldMatrix(
 }
 
 //------------------------------------------------------------------------------
+void vtkVRRenderWindowInteractor::SetStartingPhysicalToWorldMatrix(
+  vtkMatrix4x4* startingPhysicalToWorldMatrix)
+{
+  if (!startingPhysicalToWorldMatrix)
+  {
+    return;
+  }
+  this->StartingPhysicalToWorldMatrix->DeepCopy(startingPhysicalToWorldMatrix);
+}
+
+//------------------------------------------------------------------------------
 int vtkVRRenderWindowInteractor::InternalCreateTimer(
   int vtkNotUsed(timerId), int vtkNotUsed(timerType), unsigned long vtkNotUsed(duration))
 {

--- a/Rendering/VR/vtkVRRenderWindowInteractor.cxx
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.cxx
@@ -308,6 +308,18 @@ void vtkVRRenderWindowInteractor::SetStartingPhysicalToWorldMatrix(
 }
 
 //------------------------------------------------------------------------------
+void vtkVRRenderWindowInteractor::SetStartingPhysicalEventPose(
+  vtkMatrix4x4* poseMatrix, vtkEventDataDevice device)
+{
+  int pointerIndex = static_cast<int>(device);
+  if (pointerIndex < 0 || pointerIndex >= VTKI_MAX_POINTERS || !poseMatrix)
+  {
+    return;
+  }
+  this->StartingPhysicalEventPoses[pointerIndex]->DeepCopy(poseMatrix);
+}
+
+//------------------------------------------------------------------------------
 int vtkVRRenderWindowInteractor::InternalCreateTimer(
   int vtkNotUsed(timerId), int vtkNotUsed(timerType), unsigned long vtkNotUsed(duration))
 {

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -175,6 +175,7 @@ protected:
    */
   void StartEventLoop() override;
 
+public:
   ///@{
   /**
    * Handle complex gesture events. Complex gesture events recognition starts when
@@ -196,6 +197,7 @@ protected:
   virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata);
   ///@}
 
+protected:
   ///@{
   /**
    * Class variables so an exit method can be defined for this class (used to set

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -147,14 +147,6 @@ public:
 
   ///@{
   /**
-   * Assign an event or std::function to an event path.
-   */
-  virtual void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog) = 0;
-  virtual void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>) = 0;
-  ///@}
-
-  ///@{
-  /**
    * Set/Get the .json filename describing action bindings for events.
    * Based on https://github.com/ValveSoftware/openvr/wiki/Action-manifest
    * Default is empty.

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -201,6 +201,19 @@ public:
 
   ///@{
   /**
+   * When handling complex gestures you can query this value to
+   * determine how many input device are down for the gesture.
+   *
+   * Supported device values are vtkEventDataDevice::LeftController
+   * and vtkEventDataDevice::RightController.
+   *
+   * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+   */
+  int GetDeviceInputDownCount(vtkEventDataDevice device) const;
+  ///@}
+
+  ///@{
+  /**
    * Identifier of the complex gesture being handled.
    * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
    */

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -116,10 +116,22 @@ public:
   void ConvertPoseToWorldCoordinates(vtkMatrix4x4* poseInTrackingCoordinates, double pos[3],
     double wxyz[4], double ppos[3], double wdir[3]);
 
-  /*
+  /**
    * Return starting physical to world matrix.
    */
   void GetStartingPhysicalToWorldMatrix(vtkMatrix4x4* startingPhysicalToWorldMatrix);
+
+  /**
+   * Set starting physical to world matrix.
+   *
+   * This method is intended to be used when defining a custom heuristic
+   * for recognizing complex gestures.
+   *
+   * This method **does not** call `this->Modified()`.
+   *
+   * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+   */
+  void SetStartingPhysicalToWorldMatrix(vtkMatrix4x4* startingPhysicalToWorldMatrix);
 
   ///@{
   /**

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -207,9 +207,24 @@ public:
    * Supported device values are vtkEventDataDevice::LeftController
    * and vtkEventDataDevice::RightController.
    *
+   * \sa SetDeviceInputDownCount()
    * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
    */
   int GetDeviceInputDownCount(vtkEventDataDevice device) const;
+  ///@}
+
+  ///@{
+  /**
+   * You can set this value when defining a custom heuristic for recognizing
+   * complex gestures,
+   *
+   * Supported device values are vtkEventDataDevice::LeftController
+   * and vtkEventDataDevice::RightController.
+   *
+   * \sa GetDeviceInputDownCount()
+   * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+   */
+  void SetDeviceInputDownCount(vtkEventDataDevice device, int count);
   ///@}
 
   ///@{

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -192,16 +192,21 @@ public:
    *
    * Overriding both HandleComplexGestureEvents() and RecognizeComplexGesture() allows to define
    * a different heuristic.
+   *
+   * \sa GetCurrentGesture(), SetCurrentGesture()
    */
   virtual void HandleComplexGestureEvents(vtkEventData* ed);
   virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata);
   ///@}
 
+  ///@{
   /**
-   * Return the identifier of the complex gesture being handled.
+   * Identifier of the complex gesture being handled.
    * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
    */
   vtkCommand::EventIds GetCurrentGesture() const;
+  void SetCurrentGesture(vtkCommand::EventIds eid);
+  ///@}
 
 protected:
   ///@{

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -133,6 +133,18 @@ public:
    */
   void SetStartingPhysicalToWorldMatrix(vtkMatrix4x4* startingPhysicalToWorldMatrix);
 
+  /**
+   * Set starting physical event pose.
+   *
+   * This method is intended to be used when defining a custom heuristic
+   * for recognizing complex gestures.
+   *
+   * This method **does not** call `this->Modified()`.
+   *
+   * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+   */
+  void SetStartingPhysicalEventPose(vtkMatrix4x4* poseMatrix, vtkEventDataDevice device);
+
   ///@{
   /**
    * Assign an event or std::function to an event path.

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -147,6 +147,18 @@ public:
 
   ///@{
   /**
+   * Assign an event or std::function to an event path.
+   *
+   * \sa vtkOpenVRRenderWindowInteractor::AddAction
+   * \sa vtkOpenXRRenderWindowInteractor::AddAction
+   */
+  virtual void AddAction(const std::string& path, const vtkCommand::EventIds&, bool isAnalog) = 0;
+  virtual void AddAction(
+    const std::string& path, bool isAnalog, const std::function<void(vtkEventData*)>&) = 0;
+  ///@}
+
+  ///@{
+  /**
    * Set/Get the .json filename describing action bindings for events.
    * Based on https://github.com/ValveSoftware/openvr/wiki/Action-manifest
    * Default is empty.

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -197,6 +197,12 @@ public:
   virtual void RecognizeComplexGesture(vtkEventDataDevice3D* edata);
   ///@}
 
+  /**
+   * Return the identifier of the complex gesture being handled.
+   * \sa HandleComplexGestureEvents(), RecognizeComplexGesture()
+   */
+  vtkCommand::EventIds GetCurrentGesture() const;
+
 protected:
   ///@{
   /**

--- a/Rendering/VR/vtkVRRenderWindowInteractor.h
+++ b/Rendering/VR/vtkVRRenderWindowInteractor.h
@@ -123,6 +123,14 @@ public:
 
   ///@{
   /**
+   * Assign an event or std::function to an event path.
+   */
+  virtual void AddAction(std::string path, vtkCommand::EventIds, bool isAnalog) = 0;
+  virtual void AddAction(std::string path, bool isAnalog, std::function<void(vtkEventData*)>) = 0;
+  ///@}
+
+  ///@{
+  /**
    * Set/Get the .json filename describing action bindings for events.
    * Based on https://github.com/ValveSoftware/openvr/wiki/Action-manifest
    * Default is empty.


### PR DESCRIPTION
These changes correspond to commits directly pushed to the `slicer-v9.2.20230607-1ff325c54-2` and integrated in Slicer through these pull requests:
* https://github.com/Slicer/Slicer/pull/7514
* https://github.com/Slicer/Slicer/pull/7516


-----------

For convenience, description of the associated pull requests are copied below.

### Pull request #7514

Updates VTK to support the integration of multiple runtime into the SlicerVirtualReality extension.

The following merge requests, including the backported commits referenced below, have been submitted to upstream VTK for reference

* `VR: Update interactor style API adding GetMappedAction()`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10784

* `VR: Declare AddAction() functions as virtual`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10785

* `VR: Update vtkVRRenderWindowInteractor marking ComplexGesture recognition functions as public`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10786

* `VR: Add SetInteractionState() API to VR interactor style`.
  See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10789


List of VTK changes:

```
$ git shortlog 573f18292..2f050efc8 --no-merges
Jean-Christophe Fillion-Robin (11):
      [Backport MR-10784] VR: Update interactor style API adding GetMappedAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10786] VR: Mark ComplexGesture recognition functions as public
      [Backport MR-10786] VR: Add GetCurrentGesture() API for retrieving the gesture being recognized
      [Backport MR-10786] VR: Add SetCurrentGesture() API for setting the gesture being recognized
      [Backport MR-10786] VR: Add GetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetDeviceInputDownCount() API
      [Backport MR-10786] VR: Add SetStartingPhysicalToWorldMatrix() API
      [Backport MR-10786] VR: Add SetStartingPhysicalEventPose() API
      [Backport MR-10789] VR: Add SetInteractionState() API to VR interactor style
      [Backport MR-10789] VR: Improve robustness of GetInteractionState() by checking input
```


### Pull request #7516

Updates VTK to support integration of the OpenXR runtime into the SlicerVirtualReality extension.

The following merge requests, including the backported commits referenced below, have been submitted to upstream VTK for reference

* `VR: Declare AddAction() functions as virtual` See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10785

* `VR: Resolve "Not rendered" warnings after XR RenderWindow Initialization` See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10794

Additionally this commit also adds the OpenXR bindings for the oculus touch controller copied from kitware/paraview@ec4111e7c. See `Plugins/XRInterface/Plugin/pv_openxr_binding_oculus_touch_controller.json`.

List of VTK changes:

```
$ git shortlog 2f050efc8..b9aae674d --no-merges
Jean-Christophe Fillion-Robin (5):
      Revert "[Backport MR-10785] VR: Declare AddAction() functions as virtual"
      [Backport MR-10785] VR: Improve consistency in OpenVR interactor AddAction()
      [Backport MR-10785] VR: Declare AddAction() functions as virtual
      [Backport MR-10794] VR: Resolve "Not rendered" warnings after XR RenderWindow Initialization
      [SlicerVirtualReality] ENH: Add OpenXR bindings for oculus_touch
```