### PR TITLE
[slicer-v9.2.20230607-1ff325c54-2] [Backport MR-10814] OpenXRRemoting: Support building against Holographic.Remoting.OpenXr >= 2.9.3

### DIFF
--- a/Rendering/OpenXRRemoting/vtkOpenXRManagerRemoteConnection.cxx
+++ b/Rendering/OpenXRRemoting/vtkOpenXRManagerRemoteConnection.cxx
@@ -19,6 +19,13 @@
 #include "vtkResourceFileLocator.h"
 #include "vtksys/SystemTools.hxx"
 
+// Starting with Microsoft.Holographic.Remoting.OpenXr 2.9.3, the struct
+// `XrRemotingPreferredGraphicsAdapterMSFT` is defined in `openxr_msft_holographic_remoting.h`
+// and it requires the type LUID to be defined.
+// Since LUID is defined in `windows.h` (see `OpenXR-SDK-Source/specification/registry/xr.xml`),
+// we include the corresponding VTK header.
+#include <vtkWindows.h> // Defines LUID used in XrRemotingPreferredGraphicsAdapterMSFT
+
 #include <openxr_msft_holographic_remoting.h> // Defines XR_MSFT_holographic_remoting
 
 #include "XrConnectionExtensions.h" // Provides holographic remoting extensions


### PR DESCRIPTION
Starting with Microsoft.Holographic.Remoting.OpenXr 2.9.3, the struct `XrRemotingPreferredGraphicsAdapterMSFT` is defined in `openxr_msft_holographic_remoting.h` and it requires the type LUID to be defined.

Since LUID is defined in `windows.h` (see `OpenXR-SDK-Source/specification/registry/xr.xml`), we include the corresponding VTK header and fixes the following error reported when building the vtkRenderingOpenXRRemoting module:

```
C:\path\to\\OpenXRRemoting-install\build\native\include\openxr\openxr_msft_holographic_remoting.h(405,14): error
C3646: 'adapterLuid': unknown override specifier
```

Merge-request: [vtk/vtk!10814](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/10814)

------

### Reference

> Version 2.9.3 (October 26, 2023) 
>
> * Holographic Remoting using the OpenXR API now supports GPU Adapter selection through the `XrRemotingPreferredGraphicsAdapterMSFT` extension struct.

Source: https://learn.microsoft.com/en-us/windows/mixed-reality/develop/native/holographic-remoting-version-history#version-293-october-2026-2023-

As a side note, a pull-request has also been submitted to fix the incorrect header in the `MicrosoftDocs/mixed-reality` version history, see https://github.com/MicrosoftDocs/mixed-reality/pull/762