### PR TITLE
[slicer-5.6-v9.2.20230607-1ff325c54-2] [Backport MR-10814] OpenXRRemoting: Support building against Holographic.Remoting.OpenXr >= 2.9.3

### DIFF
--- a/Rendering/OpenXRRemoting/vtkOpenXRManagerRemoteConnection.cxx
+++ b/Rendering/OpenXRRemoting/vtkOpenXRManagerRemoteConnection.cxx
@@ -19,6 +19,13 @@
 #include "vtkResourceFileLocator.h"
 #include "vtksys/SystemTools.hxx"
 
+// Starting with Microsoft.Holographic.Remoting.OpenXr 2.9.3, the struct
+// `XrRemotingPreferredGraphicsAdapterMSFT` is defined in `openxr_msft_holographic_remoting.h`
+// and it requires the type LUID to be defined.
+// Since LUID is defined in `windows.h` (see `OpenXR-SDK-Source/specification/registry/xr.xml`),
+// we include the corresponding VTK header.
+#include <vtkWindows.h> // Defines LUID used in XrRemotingPreferredGraphicsAdapterMSFT
+
 #include <openxr_msft_holographic_remoting.h> // Defines XR_MSFT_holographic_remoting
 
 #include "XrConnectionExtensions.h" // Provides holographic remoting extensions


### PR DESCRIPTION
These changes correspond to the ones integrated in branch `slicer-v9.2.20230607-1ff325c54-2` through https://github.com/Slicer/VTK/pull/53