### PR TITLE
[slicer-v9.2.20230607-1ff325c54-2] Backport SSAO fixes

### DIFF
--- a/GUISupport/Qt/QVTKOpenGLNativeWidget.cxx
+++ b/GUISupport/Qt/QVTKOpenGLNativeWidget.cxx
@@ -217,6 +217,8 @@ void QVTKOpenGLNativeWidget::initializeGL()
     ostate->Reset();
     // By default, Qt sets the depth function to GL_LESS but VTK expects GL_LEQUAL
     ostate->vtkglDepthFunc(GL_LEQUAL);
+    // By default, Qt disables the depth test but VTK expects it to be enabled.
+    ostate->vtkglEnable(GL_DEPTH_TEST);
 
     // When a QOpenGLWidget is told to use a QSurfaceFormat with samples > 0,
     // QOpenGLWidget doesn't actually create a context with multi-samples and

--- a/Rendering/OpenGL2/vtkSSAOPass.cxx
+++ b/Rendering/OpenGL2/vtkSSAOPass.cxx
@@ -268,13 +268,28 @@ void vtkSSAOPass::RenderDelegate(const vtkRenderState* s, int w, int h)
   this->FrameBufferObject->AddDepthAttachment(this->DepthTexture);
   this->FrameBufferObject->StartNonOrtho(w, h);
 
+  // Clear color and depth.
+  // This is only required for the vtkRenderer built-in UseSSAO feature
+  // where the DelegatePass does not use a vtkCameraPass for clearing.
   vtkOpenGLRenderer* glRen = vtkOpenGLRenderer::SafeDownCast(s->GetRenderer());
+  if (glRen && glRen->GetUseSSAO() && glRen->GetErase())
+  {
+    vtkOpenGLState* ostate = glRen->GetState();
+    GLbitfield clear_mask = 0;
+    if (!glRen->Transparent())
+    {
+      clear_mask |= GL_COLOR_BUFFER_BIT;
+    }
 
-  vtkOpenGLState* ostate = glRen->GetState();
-  ostate->vtkglClear(GL_COLOR_BUFFER_BIT);
-  ostate->vtkglDepthMask(GL_TRUE);
-  ostate->vtkglClearDepth(1.0);
-  ostate->vtkglClear(GL_DEPTH_BUFFER_BIT);
+    if (!glRen->GetPreserveDepthBuffer())
+    {
+      ostate->vtkglClearDepth(static_cast<GLclampf>(1.0));
+      clear_mask |= GL_DEPTH_BUFFER_BIT;
+      ostate->vtkglDepthMask(GL_TRUE);
+    }
+
+    ostate->vtkglClear(clear_mask);
+  }
 
   this->DelegatePass->Render(s);
   this->NumberOfRenderedProps += this->DelegatePass->GetNumberOfRenderedProps();

--- a/Rendering/VolumeOpenGL2/vtkOpenGLGPUVolumeRayCastMapper.cxx
+++ b/Rendering/VolumeOpenGL2/vtkOpenGLGPUVolumeRayCastMapper.cxx
@@ -1368,6 +1368,7 @@ void vtkOpenGLGPUVolumeRayCastMapper::vtkInternal::CheckPropertyKeys(vtkVolume* 
   // Otherwise this breaks volume/translucent geo depth peeling.
   vtkInformation* volumeKeys = vol->GetPropertyKeys();
   this->PreserveGLState = false;
+  this->DepthMaskOverride = false;
   if (volumeKeys && volumeKeys->Has(vtkOpenGLActor::GLDepthMaskOverride()))
   {
     // Give a chance to volumes to write to the depth buffer.


### PR DESCRIPTION
These commits fix incorrect rendering of orientation marker when shadows rendering is enabled, and rendering errors after enabling and disabling shadows rendering.
