### PR TITLE
[Backport MR-11192] Make SSAO intensity configurable

### DIFF
--- a/Rendering/OpenGL2/vtkSSAOPass.cxx
+++ b/Rendering/OpenGL2/vtkSSAOPass.cxx
@@ -371,7 +371,8 @@ void vtkSSAOPass::RenderSSAO(vtkOpenGLRenderWindow* renWin, vtkMatrix4x4* projec
          "      occlusion = occlusion / float(kernelSize);\n"
          "    }\n"
          "  }\n"
-         "  gl_FragData[0] = vec4(vec3(1.0 - occlusion), 1.0);\n";
+         "  gl_FragData[0] = vec4(vec3(1.0 - clamp((occlusion - ("
+      << this->IntensityShift << ")) * (" << this->IntensityScale << "), 0.0, 1.0)), 1.0); \n";
 
     vtkShaderProgram::Substitute(FSSource, "//VTK::FSQ::Impl", ssImpl.str());
 

--- a/Rendering/OpenGL2/vtkSSAOPass.h
+++ b/Rendering/OpenGL2/vtkSSAOPass.h
@@ -131,6 +131,26 @@ public:
   vtkSetClampMacro(VolumeOpacityThreshold, double, 0.0, 1.0);
   ///@}
 
+  ///@{
+  /**
+   * Control intensity of darkening.
+   * Default is 1.0. Larger value causes stronger darkening. 0 means no darkening at all.
+   */
+  vtkGetMacro(IntensityScale, double);
+  vtkSetMacro(IntensityScale, double);
+  ///@}
+
+  ///@{
+  /**
+   * Control intensity of darkening.
+   * Range is between 0.0 and 1.0. Default is 0.0. Larger value prevents darkening
+   * lightly occluded regions, which can be particularly noticeable when IntensityScale is set to a
+   * higher value.
+   */
+  vtkGetMacro(IntensityShift, double);
+  vtkSetClampMacro(IntensityShift, double, 0.0, 1.0);
+  ///@}
+
 protected:
   vtkSSAOPass() = default;
   ~vtkSSAOPass() override = default;
@@ -172,6 +192,9 @@ protected:
   bool Blur = false;
 
   double VolumeOpacityThreshold = 0.9;
+
+  double IntensityScale = 1.0;
+  double IntensityShift = 0.0;
 
 private:
   vtkSSAOPass(const vtkSSAOPass&) = delete;


### PR DESCRIPTION
This commit allows a linear adjustment (shift and scale) of shadow intensity to vtkSSAOPass to allow making shadows darker or lighter.

The default darkening caused by SSAO-generated shadows is sometimes too strong, sometimes insufficient. The newly added IntensityScale property can make the shadow darker, while IntensityShift can be used to prevent overall darkening in lightly occluded regions.

See related discussion at https://discourse.slicer.org/t/improve-ambient-occlusion-in-volume-rendering/33590/6