### PR TITLE
[Backport MR-12354] Fix vtkAxisActor2D minor tick positions

### DIFF
--- a/Rendering/Annotation/vtkAxisActor2D.cxx
+++ b/Rendering/Annotation/vtkAxisActor2D.cxx
@@ -659,7 +659,7 @@ void vtkAxisActor2D::UpdateTicksValueAndPosition(vtkViewport* viewport)
 
     for (int minor = 1; minor <= this->NumberOfMinorTicks; minor++)
     {
-      value = value + minor * minorDelta;
+      value = value + minorDelta;
       position = (value - this->Range[0]) * scale;
       if (position > 1)
       {
@@ -877,6 +877,8 @@ void vtkAxisActor2D::BuildLabels(vtkViewport* viewport)
   }
 
   vtkPoints* pts = this->Axis->GetPoints();
+  const vtkIdType nbOfPoints = pts->GetNumberOfPoints();
+
   // Position the mappers
   for (int i = 0; i < this->NumberOfLabelsBuilt; i++)
   {
@@ -885,6 +887,11 @@ void vtkAxisActor2D::BuildLabels(vtkViewport* viewport)
     // first point in the list is the Axis start, not a tick point.
     vtkIdType startPointId = tickId * 2 + 1;
     vtkIdType endPointId = startPointId + 1;
+    if (endPointId >= nbOfPoints)
+    {
+      vtkErrorMacro("Trying to use an inexisting tick when computing label position.");
+      return;
+    }
     pts->GetPoint(endPointId, xTick);
     double theta = this->GetAxisAngle(viewport);
     double textAngle = this->LabelTextProperty->GetOrientation();


### PR DESCRIPTION
See https://gitlab.kitware.com/vtk/vtk/-/merge_requests/12354/diffs?commit_id=3be76c9fe6cfb3970e8815e410f14ddff2ca8fcb

I have locally tested that this resolves the issue I was observing. See https://discourse.vtk.org/t/vtkaxisactor2d-label-mispositioned-following-change-from-vtk-9-2-to-newer-9-4-or-9-5/15935 for the original report and python test snippet.

|Current | This PR |
|---------|---------|
|<img width="402" height="632" alt="image" src="https://github.com/user-attachments/assets/704f8fc7-1d8a-40aa-801a-5c3ae06cf2f3" />|<img width="402" height="632" alt="image" src="https://github.com/user-attachments/assets/6c0951d2-24d7-462d-88bd-1c4f93928dec" />|