### PR TITLE
OpenXR: Meta passthrough, environment depth occlusion, and frame state refactor

### DIFF
--- a/Rendering/OpenXR/CMakeLists.txt
+++ b/Rendering/OpenXR/CMakeLists.txt
@@ -1,4 +1,4 @@
-vtk_module_find_package(PACKAGE OpenXR VERSION 1.0.31)
+vtk_module_find_package(PACKAGE OpenXR VERSION 1.1.36)
 
 set(classes
   vtkOpenXRRenderWindow
@@ -17,6 +17,7 @@ set(nowrap_classes
   vtkOpenXRManagerGraphics
   vtkOpenXRManagerOpenGLGraphics
   vtkOpenXRManagerConnection
+  vtkOpenXREnvironmentDepthOcclusionPrePass
   )
 
 set(nowrap_headers

--- a/Rendering/OpenXR/XrExtensions.h
+++ b/Rendering/OpenXR/XrExtensions.h
@@ -108,6 +108,37 @@
 #define FOR_EACH_SCENE_UNDERSTANDING_SERIALIZATION_FUNCTION(_)
 #endif
 
+#ifdef XR_FB_passthrough
+#define FOR_EACH_FB_PASSTHROUGH_FUNCTION(_)                                                        \
+  _(xrCreatePassthroughFB)                                                                         \
+  _(xrDestroyPassthroughFB)                                                                        \
+  _(xrPassthroughStartFB)                                                                          \
+  _(xrPassthroughPauseFB)                                                                          \
+  _(xrCreatePassthroughLayerFB)                                                                    \
+  _(xrDestroyPassthroughLayerFB)                                                                   \
+  _(xrPassthroughLayerResumeFB)                                                                    \
+  _(xrPassthroughLayerPauseFB)                                                                     \
+  _(xrPassthroughLayerSetStyleFB)
+#else
+#define FOR_EACH_FB_PASSTHROUGH_FUNCTION(_)
+#endif
+
+#ifdef XR_META_environment_depth
+#define FOR_EACH_META_ENVIRONMENT_DEPTH_FUNCTION(_)                                                \
+  _(xrCreateEnvironmentDepthProviderMETA)                                                          \
+  _(xrDestroyEnvironmentDepthProviderMETA)                                                         \
+  _(xrStartEnvironmentDepthProviderMETA)                                                           \
+  _(xrStopEnvironmentDepthProviderMETA)                                                            \
+  _(xrCreateEnvironmentDepthSwapchainMETA)                                                         \
+  _(xrDestroyEnvironmentDepthSwapchainMETA)                                                        \
+  _(xrEnumerateEnvironmentDepthSwapchainImagesMETA)                                                \
+  _(xrGetEnvironmentDepthSwapchainStateMETA)                                                       \
+  _(xrAcquireEnvironmentDepthImageMETA)                                                            \
+  _(xrSetEnvironmentDepthHandRemovalMETA)
+#else
+#define FOR_EACH_META_ENVIRONMENT_DEPTH_FUNCTION(_)
+#endif
+
 #define FOR_EACH_EXTENSION_FUNCTION(_)                                                             \
   FOR_EACH_VISIBILITY_MASK_FUNCTION(_)                                                             \
   FOR_EACH_HAND_TRACKING_FUNCTION(_)                                                               \
@@ -118,7 +149,9 @@
   FOR_EACH_PERCEPTION_ANCHOR_INTEROP_FUNCTION(_)                                                   \
   FOR_EACH_SCENE_UNDERSTANDING_FUNCTION(_)                                                         \
   FOR_EACH_SCENE_UNDERSTANDING_SERIALIZATION_FUNCTION(_)                                           \
-  FOR_EACH_SCENE_MARKER_FUNCTION(_)
+  FOR_EACH_SCENE_MARKER_FUNCTION(_)                                                                \
+  FOR_EACH_FB_PASSTHROUGH_FUNCTION(_)                                                              \
+  FOR_EACH_META_ENVIRONMENT_DEPTH_FUNCTION(_)
 
 #define GET_INSTANCE_PROC_ADDRESS(name)                                                            \
   (void)xrGetInstanceProcAddr(                                                                     \

--- a/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.cxx
+++ b/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.cxx
@@ -750,7 +750,7 @@ void vtkOpenXREnvironmentDepthOcclusionPrePass::BuildDebugProgram()
 
 //------------------------------------------------------------------------------
 void vtkOpenXREnvironmentDepthOcclusionPrePass::DebugVisualize(uint32_t eye, vtkCamera* camera,
-  uint32_t envDepthGLTexture, const XrEnvironmentDepthImageViewMETA views[2])
+  uint32_t envDepthGLTexture, const XrEnvironmentDepthImageViewMETA views[2], float physicalScale)
 {
   if (!camera)
   {
@@ -777,8 +777,8 @@ void vtkOpenXREnvironmentDepthOcclusionPrePass::DebugVisualize(uint32_t eye, vtk
   // ------------------------------------------------------------------
   double clippingRange[2];
   camera->GetClippingRange(clippingRange);
-  const float nearZ = static_cast<float>(clippingRange[0]);
-  const float farZ  = static_cast<float>(clippingRange[1]);
+  const float nearZ = static_cast<float>(clippingRange[0]) / physicalScale;
+  const float farZ  = static_cast<float>(clippingRange[1]) / physicalScale;
 
   vtkOpenXRManager& mgr = vtkOpenXRManager::GetInstance();
   const XrPosef* vrEyePosePtr = mgr.GetViewPose(eye);

--- a/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.cxx
+++ b/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.cxx
@@ -1,0 +1,1144 @@
+// SPDX-FileCopyrightText: Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+// SPDX-License-Identifier: BSD-3-Clause
+#include "vtkOpenXREnvironmentDepthOcclusionPrePass.h"
+
+// OpenGL function pointers (loaded by VTK's GLAD-based loader).
+#include "vtk_glad.h"
+
+// XR types: XrEnvironmentDepthImageViewMETA, XrPosef, XrFovf.
+// These are available from OpenXR SDK >= 1.1.36 via the platform header.
+#include "vtkOpenXRPlatform.h"
+
+#include "vtkOpenXRManager.h" // for GetViewPose / GetProjectionFov
+
+#include "vtkCamera.h"
+#include "vtkMatrix4x4.h"
+#include "vtkNew.h"
+#include "vtkVRHMDCamera.h" // for GetPhysicalToProjectionMatrix()
+
+#include <cmath>    // std::tan
+#include <iostream> // std::cerr (shader compile diagnostics)
+
+VTK_ABI_NAMESPACE_BEGIN
+
+//------------------------------------------------------------------------------
+// Utility: convert XrPosef → column-major float[16] (pose-in-world, i.e. camera→world).
+// Output layout: mat[col*4+row].
+static void XrPoseToMatrix(const XrPosef& pose, float mat[16])
+{
+  const float x = pose.orientation.x;
+  const float y = pose.orientation.y;
+  const float z = pose.orientation.z;
+  const float w = pose.orientation.w;
+
+  // Column 0  (rotation, world-x expressed in local frame)
+  mat[0] = 1.0f - 2.0f * (y * y + z * z);
+  mat[1] = 2.0f * (x * y + w * z);
+  mat[2] = 2.0f * (x * z - w * y);
+  mat[3] = 0.0f;
+  // Column 1
+  mat[4] = 2.0f * (x * y - w * z);
+  mat[5] = 1.0f - 2.0f * (x * x + z * z);
+  mat[6] = 2.0f * (y * z + w * x);
+  mat[7] = 0.0f;
+  // Column 2
+  mat[8] = 2.0f * (x * z + w * y);
+  mat[9] = 2.0f * (y * z - w * x);
+  mat[10] = 1.0f - 2.0f * (x * x + y * y);
+  mat[11] = 0.0f;
+  // Column 3 (translation)
+  mat[12] = pose.position.x;
+  mat[13] = pose.position.y;
+  mat[14] = pose.position.z;
+  mat[15] = 1.0f;
+}
+
+//------------------------------------------------------------------------------
+// Utility: invert a column-major rigid-body (rotation+translation) float[16].
+// For M = [R | t; 0 1]:  M^-1 = [R^T | -R^T*t; 0 1].
+static void InvertRigidBody(const float m[16], float out[16])
+{
+  // Transpose the rotation block (upper-left 3×3).
+  // m[col*4+row] → out[col*4+row] = m[row*4+col]
+  for (int r = 0; r < 3; ++r)
+    for (int c = 0; c < 3; ++c)
+      out[c * 4 + r] = m[r * 4 + c];
+
+  // Compute -R^T * t  (translation in column 3)
+  for (int r = 0; r < 3; ++r)
+  {
+    float s = 0.0f;
+    for (int k = 0; k < 3; ++k)
+      s += m[k * 4 + r] * m[12 + k]; // R^T[r][k] = m[k*4+r]; t[k] = m[12+k]
+    out[12 + r] = -s;
+  }
+
+  out[3] = out[7] = out[11] = 0.0f;
+  out[15] = 1.0f;
+}
+
+//------------------------------------------------------------------------------
+// Utility: copy a VTK (row-major, double) matrix to a GL (column-major, float) array.
+static void VtkMatrixToGL(vtkMatrix4x4* m, float out[16])
+{
+  for (int row = 0; row < 4; ++row)
+    for (int col = 0; col < 4; ++col)
+      out[col * 4 + row] = static_cast<float>(m->GetElement(row, col));
+}
+
+//------------------------------------------------------------------------------
+// Utility: build a column-major GL projection matrix from an OpenXR asymmetric
+// FOV + near/far clipping planes.
+// Equivalent to glFrustum but using tangent angles directly.
+static void BuildProjectionFromFov(const XrFovf& fov, float nearZ, float farZ, float out[16])
+{
+  const float l = std::tan(fov.angleLeft);   // negative
+  const float r = std::tan(fov.angleRight);  // positive
+  const float b = std::tan(fov.angleDown);   // negative
+  const float t = std::tan(fov.angleUp);     // positive
+  const float n = nearZ, f = farZ;
+
+  // Column-major layout: out[col*4 + row]
+  // Column 0
+  out[0] = 2.0f / (r - l); out[1] = 0.0f;            out[2] = 0.0f;                out[3] = 0.0f;
+  // Column 1
+  out[4] = 0.0f;            out[5] = 2.0f / (t - b);  out[6] = 0.0f;                out[7] = 0.0f;
+  // Column 2
+  out[8]  = (r + l) / (r - l);
+  out[9]  = (t + b) / (t - b);
+  out[10] = -(f + n) / (f - n);
+  out[11] = -1.0f;
+  // Column 3
+  out[12] = 0.0f; out[13] = 0.0f; out[14] = -2.0f * f * n / (f - n); out[15] = 0.0f;
+}
+
+//------------------------------------------------------------------------------
+// Compile a single shader stage; returns 0 on failure.
+static GLuint CompileShader(GLenum type, const char* src)
+{
+  GLuint shader = glCreateShader(type);
+  glShaderSource(shader, 1, &src, nullptr);
+  glCompileShader(shader);
+
+  GLint ok = GL_FALSE;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &ok);
+  if (!ok)
+  {
+    char log[1024] = {};
+    glGetShaderInfoLog(shader, sizeof(log), nullptr, log);
+    std::cerr << "vtkOpenXREnvironmentDepthOcclusionPrePass: shader compile error:\n"
+              << log << "\n";
+    glDeleteShader(shader);
+    return 0;
+  }
+  return shader;
+}
+
+//------------------------------------------------------------------------------
+// Fullscreen triangle vertex shader.
+// Three vertices (gl_VertexID 0,1,2) produce a CCW triangle that covers [-1,1]×[-1,1].
+static const char* s_VertSrc = R"glsl(
+#version 330 core
+out vec2 vTexCoord;
+void main()
+{
+    // Vertex 0: (-1,-1)  Vertex 1: (3,-1)  Vertex 2: (-1,3)
+    // Together they cover the full NDC square via gl_VertexID.
+    float x = float((gl_VertexID & 1) << 2) - 1.0;
+    float y = float((gl_VertexID >> 1 & 1) << 2) - 1.0;
+    gl_Position = vec4(x, y, 0.0, 1.0);
+    vTexCoord   = gl_Position.xy * 0.5 + 0.5;
+}
+)glsl";
+
+//------------------------------------------------------------------------------
+// Environment-depth occlusion fragment shader.
+// For each screen pixel it:
+//   1. Unprojects the pixel into world-space ray direction (via VR proj/view).
+//   2. Reprojects that ray into the env-depth camera's local space.
+//   3. Samples the real-world radial depth using a tangent-based FOV mapping.
+//   4. Reconstructs the world-space surface point and re-projects to VR clip space.
+//   5. Writes gl_FragDepth (colour writes are disabled by Apply()).
+//
+// NOTE: vrView / envDepthViewInverse must share the same world-space coordinate
+// frame.  When VTK's PhysicalToWorldMatrix is identity (the common case), the
+// OpenXR reference-space pose is identical to the VTK world space and no
+// additional transform is required.
+static const char* s_FragSrc = R"glsl(
+#version 330 core
+
+uniform sampler2DArray envDepthTex;   // GL_TEXTURE_2D_ARRAY; layer = eye index
+
+// VR eye matrices
+uniform mat4 vrProjInverse;           // inverse of VR eye projection
+uniform mat4 vrProj;                  // VR eye projection (eye → clip)
+uniform mat4 vrView;                  // world → VR eye space
+uniform mat4 vrViewInverse;           // VR eye → world (eye pose in world)
+
+// Environment-depth camera matrices (derived from XrPosef)
+uniform mat4 envDepthViewInverse;     // env-depth camera pose in world (col3 = cam pos)
+uniform mat4 envDepthView;            // world → env-depth camera space
+
+// Precomputed tangents of the env-depth FOV angles: tan(left), tan(right), tan(down), tan(up).
+// left/down are negative; right/up are positive.
+uniform vec4 envDepthTan;
+
+uniform int eye;                      // 0 = left, 1 = right
+
+in vec2 vTexCoord;
+
+void main()
+{
+    // -----------------------------------------------------------------------
+    // 1. NDC pixel → eye-space position/direction
+    // -----------------------------------------------------------------------
+    vec2 ndc = vTexCoord * 2.0 - 1.0;
+    vec4 eyeH = vrProjInverse * vec4(ndc, 0.0, 1.0);
+    eyeH /= eyeH.w;
+    vec3 eyeDir = normalize(eyeH.xyz);
+
+    // -----------------------------------------------------------------------
+    // 2. Eye-space direction → world-space direction
+    // -----------------------------------------------------------------------
+    vec3 worldDir = normalize(mat3(vrViewInverse) * eyeDir);
+
+    // -----------------------------------------------------------------------
+    // 3. World-space direction → env-depth camera space
+    // -----------------------------------------------------------------------
+    vec3 edDir = normalize(mat3(envDepthView) * worldDir);
+
+    // In OpenXR (and OpenGL/VTK), cameras look along the NEGATIVE Z axis in
+    // their local frame.  A ray pointing INTO the camera frustum therefore has
+    // a NEGATIVE z component in env-depth camera space.  Discard any ray that
+    // points away from (behind) the camera, i.e. z >= 0.
+    if (edDir.z >= 0.0)
+    {
+        gl_FragDepth = 1.0;
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 4. Compute UV from tangent-based asymmetric FOV
+    // From the OpenXR spec: fov.angleLeft < 0, fov.angleRight > 0,
+    //                        fov.angleDown < 0, fov.angleUp   > 0.
+    // Divide by -edDir.z (positive for forward rays) to get the tangent of
+    // the angle from the optical axis.
+    // -----------------------------------------------------------------------
+    float tanLeft  = envDepthTan.x;
+    float tanRight = envDepthTan.y;
+    float tanDown  = envDepthTan.z;
+    float tanUp    = envDepthTan.w;
+
+    float u = (edDir.x / (-edDir.z) - tanLeft)  / (tanRight - tanLeft);
+    float v = (edDir.y / (-edDir.z) - tanDown)  / (tanUp    - tanDown);
+
+    if (u < 0.0 || u > 1.0 || v < 0.0 || v > 1.0)
+    {
+        gl_FragDepth = 1.0;
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 5. Sample real-world radial depth (metres along the ray)
+    // -----------------------------------------------------------------------
+    float realDepth = texture(envDepthTex, vec3(u, v, float(eye))).r;
+    if (realDepth <= 0.0)
+    {
+        gl_FragDepth = 1.0;
+        return;
+    }
+
+    // -----------------------------------------------------------------------
+    // 6. Reconstruct world-space surface point
+    //    realDepth is radial (Euclidean distance along the ray from the
+    //    env-depth camera, NOT projected z).
+    // -----------------------------------------------------------------------
+    vec3 edCamPos    = envDepthViewInverse[3].xyz;
+    vec3 edWorldDir  = normalize(mat3(envDepthViewInverse) * edDir);
+    vec3 surfaceWorld = edCamPos + edWorldDir * realDepth;
+
+    // -----------------------------------------------------------------------
+    // 7. Re-project world-space point into VR clip space → write depth
+    // -----------------------------------------------------------------------
+    vec4 vrClip = vrProj * (vrView * vec4(surfaceWorld, 1.0));
+    if (vrClip.w <= 0.0) { gl_FragDepth = 1.0; return; }
+    gl_FragDepth = (vrClip.z / vrClip.w) * 0.5 + 0.5;
+}
+)glsl";
+
+//------------------------------------------------------------------------------
+// Debug visualisation fragment shader.
+// Uses identical reprojection to s_FragSrc but outputs a false-colour depth
+// image as an alpha-blended colour overlay instead of writing gl_FragDepth.
+//
+//   red   = near  (0 m)
+//   blue  = far   (~5 m, controlled by uniform depthScale)
+//   black = outside env-depth frustum or invalid pixel
+//   alpha = 0.75  (semi-transparent so the underlying scene shows through)
+//
+static const char* s_DebugFragSrc = R"glsl(
+#version 330 core
+
+uniform sampler2DArray envDepthTex;
+uniform mat4 vrProjInverse;
+uniform mat4 vrView;
+uniform mat4 vrViewInverse;
+uniform mat4 envDepthViewInverse;
+uniform mat4 envDepthView;
+uniform vec4 envDepthTan;   // precomputed tan() of FOV angles: left, right, down, up
+uniform int  eye;
+uniform float depthScale;   // metres at which the colour reaches full blue (default 5.0)
+
+in  vec2 vTexCoord;
+out vec4 fragColor;
+
+vec3 hsv2rgb(vec3 c)
+{
+    vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+void main()
+{
+    // 1. NDC → eye-space direction (reuse vrProjInverse)
+    vec2 ndc  = vTexCoord * 2.0 - 1.0;
+    vec4 eyeH = vrProjInverse * vec4(ndc, 0.0, 1.0);
+    eyeH /= eyeH.w;
+    vec3 eyeDir = normalize(eyeH.xyz);
+
+    // 2. Eye → world
+    vec3 worldDir = normalize(mat3(vrViewInverse) * eyeDir);
+
+    // 3. World → env-depth camera space
+    vec3 edDir = normalize(mat3(envDepthView) * worldDir);
+
+    // OpenXR -Z-forward: forward rays have edDir.z < 0
+    if (edDir.z >= 0.0)
+    {
+        discard;
+    }
+
+    // 4. Tangent-based UV
+    float tanLeft  = envDepthTan.x;
+    float tanRight = envDepthTan.y;
+    float tanDown  = envDepthTan.z;
+    float tanUp    = envDepthTan.w;
+
+    float u = (edDir.x / (-edDir.z) - tanLeft) / (tanRight - tanLeft);
+    float v = (edDir.y / (-edDir.z) - tanDown) / (tanUp    - tanDown);
+
+    if (u < 0.0 || u > 1.0 || v < 0.0 || v > 1.0)
+    {
+        discard;
+    }
+
+    // 5. Sample real-world depth
+    float realDepth = texture(envDepthTex, vec3(u, v, float(eye))).r;
+    if (realDepth <= 0.0)
+    {
+        discard;
+    }
+
+    // 6. Map depth → false colour
+    float t = clamp(realDepth / depthScale, 0.0, 1.0);
+    vec3 color = hsv2rgb(vec3(t, 1.0, 1.0));
+
+    // alpha = 0.75: semi-transparent so the underlying scene shows through
+    fragColor = vec4(color, 0.75);
+}
+)glsl";
+
+//------------------------------------------------------------------------------
+// Partial occlusion post-pass fragment shader.
+// Same reprojection as s_FragSrc but uses gl_FragDepth for the depth TEST
+// (GL_LESS, no depth WRITE) to detect pixels where virtual geometry is behind
+// the real world, and outputs an alpha value that, combined with the caller's
+// blend state, multiplies the existing colour alpha by occludedOpacity.
+//
+// Blend setup used by the caller:
+//   glBlendFuncSeparate(GL_ZERO, GL_ONE, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA)
+//   glColorMask(false, false, false, true)  — alpha channel only
+//
+// This fragment outputs src.a = (1 - occludedOpacity).
+// Effect per fragment that passes the depth test (GL_ONE_MINUS_SRC_ALPHA dst factor):
+//   result.a = dst.a * (1 - src.a)
+//            = dst.a * occludedOpacity
+//
+// Empty pixels (dst.a = 0) are therefore left at 0; only pixels where the
+// scene rendered visible geometry have their alpha scaled down.
+//
+static const char* s_OcclusionPostPassFragSrc = R"glsl(
+#version 330 core
+
+uniform sampler2DArray envDepthTex;
+uniform mat4 vrProjInverse;
+// physicalToClip = VTK's actual PhysicalToProjectionMatrix for the active eye.
+// Using VTK's own matrix (rather than rebuilding from FOV + near/far) guarantees
+// that the gl_FragDepth values we write are encoded identically to the values
+// already in the scene depth buffer, so the GL_LESS comparison is valid.
+uniform mat4 physicalToClip;
+uniform mat4 vrViewInverse;
+uniform mat4 envDepthViewInverse;
+uniform mat4 envDepthView;
+uniform vec4 envDepthTan;   // precomputed tan() of FOV angles: left, right, down, up
+uniform int  eye;
+// occludedOpacity in [0, 1):
+//   0.0 = completely occlude (result alpha → 0)
+//   0.5 = half transparent   (result alpha → 0.5 * original)
+uniform float occludedOpacity;
+
+// Gaussian sigma in texels of the env-depth texture.  Blurs the raw depth
+// values before the depth comparison so that low-resolution sensor data does
+// not produce a blocky occlusion boundary.
+uniform float sigmaTexels;
+
+in  vec2 vTexCoord;
+out vec4 fragColor;
+
+void main()
+{
+    // 1. NDC → eye-space direction
+    vec2 ndc  = vTexCoord * 2.0 - 1.0;
+    vec4 eyeH = vrProjInverse * vec4(ndc, 0.0, 1.0);
+    eyeH /= eyeH.w;
+    vec3 eyeDir = normalize(eyeH.xyz);
+
+    // 2. Eye → physical (OpenXR reference) space direction
+    vec3 worldDir = normalize(mat3(vrViewInverse) * eyeDir);
+
+    // 3. Physical → env-depth camera space
+    vec3 edDir = normalize(mat3(envDepthView) * worldDir);
+
+    // OpenXR -Z-forward: forward rays have edDir.z < 0
+    if (edDir.z >= 0.0)
+    {
+        discard;
+    }
+
+    // 4. Tangent-based UV
+    float tanLeft  = envDepthTan.x;
+    float tanRight = envDepthTan.y;
+    float tanDown  = envDepthTan.z;
+    float tanUp    = envDepthTan.w;
+
+    float u = (edDir.x / (-edDir.z) - tanLeft) / (tanRight - tanLeft);
+    float v = (edDir.y / (-edDir.z) - tanDown) / (tanUp    - tanDown);
+
+    if (u < 0.0 || u > 1.0 || v < 0.0 || v > 1.0)
+    {
+        discard;
+    }
+
+    // 5. Sample real-world depth (metres, euclidean) with a Gaussian blur over
+    //    the env-depth texture.  This smooths the raw depth values from the
+    //    low-resolution sensor before comparison so that the resulting occlusion
+    //    boundary is not limited by the sensor's pixel grid.
+    //    Only valid (non-zero) depth texels contribute to the weighted sum,
+    //    so that missing/invalid pixels at the sensor boundary do not bias the
+    //    depth estimate inward.
+    float realDepth;
+    {
+        ivec3 edSize     = textureSize(envDepthTex, 0);
+        vec2  edTexelSize = 1.0 / vec2(edSize.xy);
+        float s2         = 2.0 * sigmaTexels * sigmaTexels;
+        float depthAcc   = 0.0;
+        float wSum       = 0.0;
+        for (int dy = -2; dy <= 2; ++dy)
+        {
+            for (int dx = -2; dx <= 2; ++dx)
+            {
+                float w   = exp(-float(dx * dx + dy * dy) / s2);
+                vec2  uv2 = clamp(vec2(u, v) + vec2(float(dx), float(dy)) * edTexelSize,
+                                  0.0, 1.0);
+                float d   = texture(envDepthTex, vec3(uv2, float(eye))).r;
+                if (d > 0.0) { depthAcc += w * d; wSum += w; }
+            }
+        }
+        if (wSum <= 0.0) { discard; }
+        realDepth = depthAcc / wSum;
+    }
+
+    // 6. Reconstruct physical-space surface point
+    //    realDepth is radial distance from the env-depth camera along the ray.
+    vec3 edCamPos    = envDepthViewInverse[3].xyz;
+    vec3 edWorldDir  = normalize(mat3(envDepthViewInverse) * edDir);
+    vec3 surfaceWorld = edCamPos + edWorldDir * realDepth;
+
+    // 7. Re-project to VR clip space using VTK's own physical→clip matrix.
+    //    This ensures gl_FragDepth is on the same scale as the scene depth buffer.
+    vec4 vrClip = physicalToClip * vec4(surfaceWorld, 1.0);
+
+    // Guard against degenerate projections (object behind or at camera).
+    if (vrClip.w <= 0.0) { discard; }
+
+    // A small positive bias shifts the real-world depth slightly away from
+    // the camera so that virtual geometry at exactly the same distance as
+    // a real surface is treated as "in front" and left visible.  This
+    // prevents false occlusion at the boundary.  1e-4 in NDC corresponds
+    // to a sub-centimetre tolerance at typical XR working distances.
+    gl_FragDepth = (vrClip.z / vrClip.w) * 0.5 + 0.5 + 1e-4;
+
+    // Depth test passes for occluded pixels.  The caller uses
+    // glBlendFuncSeparate(GL_ZERO, GL_ONE, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA)
+    // so the result alpha = dst.a * (1 - src.a) = dst.a * occludedOpacity.
+    fragColor = vec4(0.0, 0.0, 0.0, 1.0 - occludedOpacity);
+}
+)glsl";
+
+//------------------------------------------------------------------------------
+vtkOpenXREnvironmentDepthOcclusionPrePass::vtkOpenXREnvironmentDepthOcclusionPrePass() = default;
+
+//------------------------------------------------------------------------------
+vtkOpenXREnvironmentDepthOcclusionPrePass::~vtkOpenXREnvironmentDepthOcclusionPrePass()
+{
+  if (this->Program)
+  {
+    glDeleteProgram(this->Program);
+  }
+  if (this->DebugProgram)
+  {
+    glDeleteProgram(this->DebugProgram);
+  }
+  if (this->OcclusionPostPassProgram)
+  {
+    glDeleteProgram(this->OcclusionPostPassProgram);
+  }
+  if (this->VAO)
+  {
+    glDeleteVertexArrays(1, &this->VAO);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::BuildProgram()
+{
+  GLuint vert = CompileShader(GL_VERTEX_SHADER, s_VertSrc);
+  GLuint frag = CompileShader(GL_FRAGMENT_SHADER, s_FragSrc);
+
+  if (!vert || !frag)
+  {
+    glDeleteShader(vert);
+    glDeleteShader(frag);
+    return;
+  }
+
+  GLuint prog = glCreateProgram();
+  glAttachShader(prog, vert);
+  glAttachShader(prog, frag);
+  glLinkProgram(prog);
+
+  glDeleteShader(vert);
+  glDeleteShader(frag);
+
+  GLint ok = GL_FALSE;
+  glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+  if (!ok)
+  {
+    char log[1024] = {};
+    glGetProgramInfoLog(prog, sizeof(log), nullptr, log);
+    std::cerr << "vtkOpenXREnvironmentDepthOcclusionPrePass: program link error:\n"
+              << log << "\n";
+    glDeleteProgram(prog);
+    return;
+  }
+
+  this->Program = static_cast<uint32_t>(prog);
+
+  glGenVertexArrays(1, &this->VAO);
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::Apply(uint32_t eye, vtkCamera* camera,
+  uint32_t envDepthGLTexture, const XrEnvironmentDepthImageViewMETA views[2],
+  float physicalScale)
+{
+  if (!camera)
+  {
+    return;
+  }
+
+  // Lazy-initialise the GLSL program on first use.
+  if (!this->Program)
+  {
+    this->BuildProgram();
+    if (!this->Program)
+    {
+      return; // shader compilation failed — silently skip
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Compute uniforms from camera and pose data.
+  // ------------------------------------------------------------------
+
+  // Clipping planes — independent of which eye is active on the camera.
+  // camera->GetClippingRange() returns values in VTK world units.  The env-depth
+  // shader works in OpenXR metres, which are related by PhysicalScale:
+  //   vtk_world_unit = openxr_metre * PhysicalScale
+  // Dividing near/far by PhysicalScale converts them to metres so that the
+  // projection matrix built here matches the depth values the shader produces.
+  double clippingRange[2];
+  camera->GetClippingRange(clippingRange);
+  const float nearZ = static_cast<float>(clippingRange[0]) / physicalScale;
+  const float farZ  = static_cast<float>(clippingRange[1]) / physicalScale;
+
+  // VR eye matrices: derive directly from OpenXR view data so that the
+  // result is correct regardless of whether VTK has called SetLeftEye()
+  // yet for this eye.
+  vtkOpenXRManager& mgr = vtkOpenXRManager::GetInstance();
+  const XrPosef* vrEyePosePtr = mgr.GetViewPose(eye);
+  const XrFovf*  vrFovPtr     = mgr.GetProjectionFov(eye);
+  if (!vrEyePosePtr || !vrFovPtr)
+  {
+    return; // session not started or view data not initialised
+  }
+
+  // Build VR projection from FOV + near/far.
+  float vrProj[16];
+  BuildProjectionFromFov(*vrFovPtr, nearZ, farZ, vrProj);
+
+  // Invert the projection matrix for use in the unproject step.
+  float vrProjInverse[16];
+  {
+    vtkNew<vtkMatrix4x4> projMat;
+    for (int row = 0; row < 4; ++row)
+      for (int col = 0; col < 4; ++col)
+        projMat->SetElement(row, col, static_cast<double>(vrProj[col * 4 + row]));
+    vtkNew<vtkMatrix4x4> projInvMat;
+    vtkMatrix4x4::Invert(projMat, projInvMat);
+    VtkMatrixToGL(projInvMat, vrProjInverse);
+  }
+
+  // Build VR view matrix from the eye pose (OpenXR reference space).
+  float vrViewInverse[16]; // eye-in-world (pose → column-major matrix)
+  XrPoseToMatrix(*vrEyePosePtr, vrViewInverse);
+  float vrView[16];        // world-to-eye
+  InvertRigidBody(vrViewInverse, vrView);
+
+  // Environment-depth camera pose (world → envDepth camera).
+  // XrPosef is in the OpenXR reference space, which coincides with VTK world
+  // space when PhysicalToWorldMatrix is identity.
+  const XrEnvironmentDepthImageViewMETA& view = views[eye];
+  float envDepthViewInverse[16]; // pose (XrPosef) → camera-in-world
+  XrPoseToMatrix(view.pose, envDepthViewInverse);
+  float envDepthViewMat[16]; // world → env-depth camera space
+  InvertRigidBody(envDepthViewInverse, envDepthViewMat);
+
+  // Precomputed FOV tangents (avoids per-fragment tan() in the shader).
+  const XrFovf& fov = view.fov;
+  float envDepthTan[4] = {
+    std::tan(fov.angleLeft),  // x  (negative)
+    std::tan(fov.angleRight), // y  (positive)
+    std::tan(fov.angleDown),  // z  (negative)
+    std::tan(fov.angleUp),    // w  (positive)
+  };
+
+  // ------------------------------------------------------------------
+  // Save GL state.
+  // ------------------------------------------------------------------
+  GLboolean colorMask[4];
+  glGetBooleanv(GL_COLOR_WRITEMASK, colorMask);
+  GLboolean depthMask;
+  glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask);
+  GLboolean depthTestEnabled = glIsEnabled(GL_DEPTH_TEST);
+  GLint depthFunc;
+  glGetIntegerv(GL_DEPTH_FUNC, &depthFunc);
+  GLint prevProgram;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &prevProgram);
+  GLint prevActiveTexUnit;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActiveTexUnit);
+  GLint prevTexBinding;
+  glActiveTexture(GL_TEXTURE0);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &prevTexBinding);
+  GLint prevVAO;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &prevVAO);
+
+  // ------------------------------------------------------------------
+  // Configure GL for depth-only pre-pass.
+  // ------------------------------------------------------------------
+  glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE); // no colour writes
+  glEnable(GL_DEPTH_TEST);
+  glDepthMask(GL_TRUE);
+  glDepthFunc(GL_ALWAYS); // unconditionally write all depths
+
+  // ------------------------------------------------------------------
+  // Draw the fullscreen triangle with the depth shader.
+  // ------------------------------------------------------------------
+  glUseProgram(static_cast<GLuint>(this->Program));
+
+  // Bind textures.
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(envDepthGLTexture));
+  glUniform1i(glGetUniformLocation(this->Program, "envDepthTex"), 0);
+
+  // Upload matrices and scalars.
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->Program, "vrProjInverse"), 1, GL_FALSE, vrProjInverse);
+  glUniformMatrix4fv(glGetUniformLocation(this->Program, "vrProj"), 1, GL_FALSE, vrProj);
+  glUniformMatrix4fv(glGetUniformLocation(this->Program, "vrView"), 1, GL_FALSE, vrView);
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->Program, "vrViewInverse"), 1, GL_FALSE, vrViewInverse);
+  glUniformMatrix4fv(glGetUniformLocation(this->Program, "envDepthViewInverse"), 1, GL_FALSE,
+    envDepthViewInverse);
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->Program, "envDepthView"), 1, GL_FALSE, envDepthViewMat);
+  glUniform4fv(glGetUniformLocation(this->Program, "envDepthTan"), 1, envDepthTan);
+  glUniform1i(glGetUniformLocation(this->Program, "eye"), static_cast<GLint>(eye));
+
+  glBindVertexArray(static_cast<GLuint>(this->VAO));
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+
+  // ------------------------------------------------------------------
+  // Restore GL state.
+  // ------------------------------------------------------------------
+  glBindVertexArray(static_cast<GLuint>(prevVAO));
+  glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
+  glDepthMask(depthMask);
+  glDepthFunc(static_cast<GLenum>(depthFunc));
+  if (!depthTestEnabled)
+  {
+    glDisable(GL_DEPTH_TEST);
+  }
+  glUseProgram(static_cast<GLuint>(prevProgram));
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(prevTexBinding));
+  glActiveTexture(static_cast<GLenum>(prevActiveTexUnit));
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::BuildDebugProgram()
+{
+  GLuint vert = CompileShader(GL_VERTEX_SHADER, s_VertSrc);
+  GLuint frag = CompileShader(GL_FRAGMENT_SHADER, s_DebugFragSrc);
+
+  if (!vert || !frag)
+  {
+    glDeleteShader(vert);
+    glDeleteShader(frag);
+    return;
+  }
+
+  GLuint prog = glCreateProgram();
+  glAttachShader(prog, vert);
+  glAttachShader(prog, frag);
+  glLinkProgram(prog);
+
+  glDeleteShader(vert);
+  glDeleteShader(frag);
+
+  GLint ok = GL_FALSE;
+  glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+  if (!ok)
+  {
+    char log[1024] = {};
+    glGetProgramInfoLog(prog, sizeof(log), nullptr, log);
+    std::cerr << "vtkOpenXREnvironmentDepthOcclusionPrePass: debug program link error:\n"
+              << log << "\n";
+    glDeleteProgram(prog);
+    return;
+  }
+
+  this->DebugProgram = static_cast<uint32_t>(prog);
+
+  // Re-use the VAO already created by BuildProgram(); create it here if this
+  // method is somehow called standalone.
+  if (!this->VAO)
+  {
+    glGenVertexArrays(1, &this->VAO);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::DebugVisualize(uint32_t eye, vtkCamera* camera,
+  uint32_t envDepthGLTexture, const XrEnvironmentDepthImageViewMETA views[2])
+{
+  if (!camera)
+  {
+    return;
+  }
+
+  // Ensure the shared VAO exists (may have been created by BuildProgram already).
+  if (!this->DebugProgram)
+  {
+    // Also builds the VAO if not yet present.
+    if (!this->VAO)
+    {
+      glGenVertexArrays(1, &this->VAO);
+    }
+    this->BuildDebugProgram();
+    if (!this->DebugProgram)
+    {
+      return;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Build the same uniforms as Apply().
+  // ------------------------------------------------------------------
+  double clippingRange[2];
+  camera->GetClippingRange(clippingRange);
+  const float nearZ = static_cast<float>(clippingRange[0]);
+  const float farZ  = static_cast<float>(clippingRange[1]);
+
+  vtkOpenXRManager& mgr = vtkOpenXRManager::GetInstance();
+  const XrPosef* vrEyePosePtr = mgr.GetViewPose(eye);
+  const XrFovf*  vrFovPtr     = mgr.GetProjectionFov(eye);
+  if (!vrEyePosePtr || !vrFovPtr)
+  {
+    return;
+  }
+
+  float vrProj[16];
+  BuildProjectionFromFov(*vrFovPtr, nearZ, farZ, vrProj);
+
+  float vrProjInverse[16];
+  {
+    vtkNew<vtkMatrix4x4> projMat;
+    for (int row = 0; row < 4; ++row)
+      for (int col = 0; col < 4; ++col)
+        projMat->SetElement(row, col, static_cast<double>(vrProj[col * 4 + row]));
+    vtkNew<vtkMatrix4x4> projInvMat;
+    vtkMatrix4x4::Invert(projMat, projInvMat);
+    VtkMatrixToGL(projInvMat, vrProjInverse);
+  }
+
+  float vrViewInverse[16];
+  XrPoseToMatrix(*vrEyePosePtr, vrViewInverse);
+  float vrView[16];
+  InvertRigidBody(vrViewInverse, vrView);
+
+  const XrEnvironmentDepthImageViewMETA& view = views[eye];
+  float envDepthViewInverse[16];
+  XrPoseToMatrix(view.pose, envDepthViewInverse);
+  float envDepthViewMat[16];
+  InvertRigidBody(envDepthViewInverse, envDepthViewMat);
+
+  const XrFovf& fov = view.fov;
+  float envDepthTan[4] = { std::tan(fov.angleLeft), std::tan(fov.angleRight),
+    std::tan(fov.angleDown), std::tan(fov.angleUp) };
+
+  // ------------------------------------------------------------------
+  // Save GL state.
+  // ------------------------------------------------------------------
+  GLboolean colorMask[4];
+  glGetBooleanv(GL_COLOR_WRITEMASK, colorMask);
+  GLboolean depthMask;
+  glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask);
+  GLboolean depthTestEnabled = glIsEnabled(GL_DEPTH_TEST);
+  GLboolean blendEnabled = glIsEnabled(GL_BLEND);
+  GLint blendSrcRGB, blendDstRGB, blendSrcAlpha, blendDstAlpha;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrcRGB);
+  glGetIntegerv(GL_BLEND_DST_RGB, &blendDstRGB);
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcAlpha);
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDstAlpha);
+  GLint prevProgram;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &prevProgram);
+  GLint prevActiveTexUnit;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActiveTexUnit);
+  GLint prevTexBinding;
+  glActiveTexture(GL_TEXTURE0);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &prevTexBinding);
+  GLint prevVAO;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &prevVAO);
+
+  // ------------------------------------------------------------------
+  // Configure GL: colour overlay on top of scene, no depth writes.
+  // ------------------------------------------------------------------
+  glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+  glDisable(GL_DEPTH_TEST); // overlay on top of everything
+  glDepthMask(GL_FALSE);    // do not disturb the depth buffer
+  glEnable(GL_BLEND);
+  glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+
+  // ------------------------------------------------------------------
+  // Draw.
+  // ------------------------------------------------------------------
+  glUseProgram(static_cast<GLuint>(this->DebugProgram));
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(envDepthGLTexture));
+  glUniform1i(glGetUniformLocation(this->DebugProgram, "envDepthTex"), 0);
+
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->DebugProgram, "vrProjInverse"), 1, GL_FALSE, vrProjInverse);
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->DebugProgram, "vrView"), 1, GL_FALSE, vrView);
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->DebugProgram, "vrViewInverse"), 1, GL_FALSE, vrViewInverse);
+  glUniformMatrix4fv(glGetUniformLocation(this->DebugProgram, "envDepthViewInverse"), 1, GL_FALSE,
+    envDepthViewInverse);
+  glUniformMatrix4fv(
+    glGetUniformLocation(this->DebugProgram, "envDepthView"), 1, GL_FALSE, envDepthViewMat);
+  glUniform4fv(glGetUniformLocation(this->DebugProgram, "envDepthTan"), 1, envDepthTan);
+  glUniform1i(glGetUniformLocation(this->DebugProgram, "eye"), static_cast<GLint>(eye));
+  glUniform1f(glGetUniformLocation(this->DebugProgram, "depthScale"), 5.0f);
+
+  glBindVertexArray(static_cast<GLuint>(this->VAO));
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+
+  // ------------------------------------------------------------------
+  // Restore GL state.
+  // ------------------------------------------------------------------
+  glBindVertexArray(static_cast<GLuint>(prevVAO));
+  glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
+  glDepthMask(depthMask);
+  if (depthTestEnabled)
+  {
+    glEnable(GL_DEPTH_TEST);
+  }
+  glBlendFuncSeparate(static_cast<GLenum>(blendSrcRGB), static_cast<GLenum>(blendDstRGB),
+    static_cast<GLenum>(blendSrcAlpha), static_cast<GLenum>(blendDstAlpha));
+  if (!blendEnabled)
+  {
+    glDisable(GL_BLEND);
+  }
+  glUseProgram(static_cast<GLuint>(prevProgram));
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(prevTexBinding));
+  glActiveTexture(static_cast<GLenum>(prevActiveTexUnit));
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::BuildOcclusionPostPassProgram()
+{
+  GLuint vert = CompileShader(GL_VERTEX_SHADER, s_VertSrc);
+  GLuint frag = CompileShader(GL_FRAGMENT_SHADER, s_OcclusionPostPassFragSrc);
+
+  if (!vert || !frag)
+  {
+    glDeleteShader(vert);
+    glDeleteShader(frag);
+    return;
+  }
+
+  GLuint prog = glCreateProgram();
+  glAttachShader(prog, vert);
+  glAttachShader(prog, frag);
+  glLinkProgram(prog);
+
+  glDeleteShader(vert);
+  glDeleteShader(frag);
+
+  GLint ok = GL_FALSE;
+  glGetProgramiv(prog, GL_LINK_STATUS, &ok);
+  if (!ok)
+  {
+    char log[1024] = {};
+    glGetProgramInfoLog(prog, sizeof(log), nullptr, log);
+    std::cerr << "vtkOpenXREnvironmentDepthOcclusionPrePass: occlusion post-pass link error:\n"
+              << log << "\n";
+    glDeleteProgram(prog);
+    return;
+  }
+
+  this->OcclusionPostPassProgram = static_cast<uint32_t>(prog);
+
+  if (!this->VAO)
+  {
+    glGenVertexArrays(1, &this->VAO);
+  }
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXREnvironmentDepthOcclusionPrePass::ApplyOcclusionPostPass(uint32_t eye,
+  vtkCamera* camera, uint32_t envDepthGLTexture, const XrEnvironmentDepthImageViewMETA views[2],
+  float occludedOpacity, float physicalScale, float sigmaTexels)
+{
+  if (!camera || occludedOpacity >= 1.0f)
+  {
+    return; // nothing to do
+  }
+
+  if (!this->OcclusionPostPassProgram)
+  {
+    if (!this->VAO)
+    {
+      glGenVertexArrays(1, &this->VAO);
+    }
+    this->BuildOcclusionPostPassProgram();
+    if (!this->OcclusionPostPassProgram)
+    {
+      return;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Compute uniforms.
+  // ------------------------------------------------------------------
+  // physicalToClip: use VTK's own PhysicalToProjectionMatrix so that the
+  // gl_FragDepth values we emit are encoded on exactly the same scale as
+  // the depths already in the scene depth buffer.  Building this from FOV +
+  // clippingRange/physicalScale is unreliable because VTK may auto-adjust
+  // clipping planes during rendering, making the near/far values differ.
+  float physicalToClip[16];
+  {
+    vtkVRHMDCamera* vrCam = vtkVRHMDCamera::SafeDownCast(camera);
+    if (!vrCam)
+    {
+      return; // not a VR camera — can't obtain the correct matrix
+    }
+    vtkMatrix4x4* mat = nullptr;
+    vrCam->GetPhysicalToProjectionMatrix(mat);
+    if (!mat)
+    {
+      return;
+    }
+    VtkMatrixToGL(mat, physicalToClip);
+  }
+
+  // vrProjInverse: used only to unproject screen NDC → eye-space ray direction
+  // (step 1 in the shader).  A small inaccuracy here just shifts WHERE we
+  // sample the env-depth texture, not the depth comparison result.
+  vtkOpenXRManager& mgr = vtkOpenXRManager::GetInstance();
+  const XrPosef* vrEyePosePtr = mgr.GetViewPose(eye);
+  const XrFovf*  vrFovPtr     = mgr.GetProjectionFov(eye);
+  if (!vrEyePosePtr || !vrFovPtr)
+  {
+    return;
+  }
+
+  double clippingRange[2];
+  camera->GetClippingRange(clippingRange);
+  const float nearZ = static_cast<float>(clippingRange[0]) / physicalScale;
+  const float farZ  = static_cast<float>(clippingRange[1]) / physicalScale;
+
+  float vrProjForInverse[16];
+  BuildProjectionFromFov(*vrFovPtr, nearZ, farZ, vrProjForInverse);
+
+  float vrProjInverse[16];
+  {
+    vtkNew<vtkMatrix4x4> projMat;
+    for (int row = 0; row < 4; ++row)
+      for (int col = 0; col < 4; ++col)
+        projMat->SetElement(row, col, static_cast<double>(vrProjForInverse[col * 4 + row]));
+    vtkNew<vtkMatrix4x4> projInvMat;
+    vtkMatrix4x4::Invert(projMat, projInvMat);
+    VtkMatrixToGL(projInvMat, vrProjInverse);
+  }
+
+  // vrViewInverse: eye pose in OpenXR physical space.
+  // Used only for transforming eye-space ray directions to physical space
+  // (step 2 in the shader).
+  float vrViewInverse[16];
+  XrPoseToMatrix(*vrEyePosePtr, vrViewInverse);
+
+  const XrEnvironmentDepthImageViewMETA& view = views[eye];
+  float envDepthViewInverse[16];
+  XrPoseToMatrix(view.pose, envDepthViewInverse);
+  float envDepthViewMat[16];
+  InvertRigidBody(envDepthViewInverse, envDepthViewMat);
+
+  const XrFovf& fov = view.fov;
+  float envDepthTan[4] = { std::tan(fov.angleLeft), std::tan(fov.angleRight),
+    std::tan(fov.angleDown), std::tan(fov.angleUp) };
+
+  // ------------------------------------------------------------------
+  // Save GL state.
+  // ------------------------------------------------------------------
+  GLboolean colorMask[4];
+  glGetBooleanv(GL_COLOR_WRITEMASK, colorMask);
+  GLboolean depthMask;
+  glGetBooleanv(GL_DEPTH_WRITEMASK, &depthMask);
+  GLboolean depthTestEnabled = glIsEnabled(GL_DEPTH_TEST);
+  GLint depthFunc;
+  glGetIntegerv(GL_DEPTH_FUNC, &depthFunc);
+  GLboolean blendEnabled = glIsEnabled(GL_BLEND);
+  GLint blendSrcRGB, blendDstRGB, blendSrcAlpha, blendDstAlpha;
+  glGetIntegerv(GL_BLEND_SRC_RGB, &blendSrcRGB);
+  glGetIntegerv(GL_BLEND_DST_RGB, &blendDstRGB);
+  glGetIntegerv(GL_BLEND_SRC_ALPHA, &blendSrcAlpha);
+  glGetIntegerv(GL_BLEND_DST_ALPHA, &blendDstAlpha);
+  GLint prevProgram;
+  glGetIntegerv(GL_CURRENT_PROGRAM, &prevProgram);
+  GLint prevActiveTexUnit;
+  glGetIntegerv(GL_ACTIVE_TEXTURE, &prevActiveTexUnit);
+  GLint prevTexBinding;
+  glActiveTexture(GL_TEXTURE0);
+  glGetIntegerv(GL_TEXTURE_BINDING_2D_ARRAY, &prevTexBinding);
+  GLint prevVAO;
+  glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &prevVAO);
+
+  // ------------------------------------------------------------------
+  // Configure GL.
+  //   - GL_LEQUAL depth test: passes when realWorldDepth <= sceneDepth
+  //                           (virtual geometry is BEHIND the real world)
+  //   - Depth mask false: do not overwrite the scene's depth values
+  //   - Color mask alpha-only: only the alpha channel is modified
+  //   - Multiplicative alpha blend: result.a = dst.a * occludedOpacity
+  //     (empty pixels with dst.a=0 are unaffected; see shader comment)
+  // ------------------------------------------------------------------
+  glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE); // alpha only
+  glEnable(GL_DEPTH_TEST);
+  // GL_LEQUAL (rather than GL_LESS) handles the case where the real-world
+  // surface sits at exactly the same NDC depth as the virtual geometry due
+  // to the 1e-4 bias applied in the shader.
+  glDepthFunc(GL_LEQUAL);
+  glDepthMask(GL_FALSE);
+  // Multiplicative alpha blend: result.a = dst.a * (1 - src.a).
+  // With the shader outputting src.a = (1 - occludedOpacity) this gives
+  //   result.a = dst.a * occludedOpacity
+  // so only pixels that actually have rendered geometry (dst.a > 0) are
+  // affected; empty/background pixels remain fully transparent.
+  glEnable(GL_BLEND);
+  glBlendFuncSeparate(GL_ZERO, GL_ONE, GL_ZERO, GL_ONE_MINUS_SRC_ALPHA);
+
+  // ------------------------------------------------------------------
+  // Draw.
+  // ------------------------------------------------------------------
+  glUseProgram(static_cast<GLuint>(this->OcclusionPostPassProgram));
+
+  glActiveTexture(GL_TEXTURE0);
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(envDepthGLTexture));
+  glUniform1i(glGetUniformLocation(this->OcclusionPostPassProgram, "envDepthTex"), 0);
+
+  // The OpenXR runtime typically creates the env-depth texture with GL_NEAREST
+  // filtering.  Force GL_LINEAR so depth values interpolate bi-linearly across
+  // texel boundaries, producing a smoothly-varying depth threshold at real-world
+  // object edges rather than a staircase-aliased boundary.
+  GLint origEnvDepthMinFilter, origEnvDepthMagFilter;
+  glGetTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, &origEnvDepthMinFilter);
+  glGetTexParameteriv(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, &origEnvDepthMagFilter);
+  glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+  auto loc = [&](const char* n) {
+    return glGetUniformLocation(this->OcclusionPostPassProgram, n);
+  };
+  glUniformMatrix4fv(loc("vrProjInverse"),       1, GL_FALSE, vrProjInverse);
+  glUniformMatrix4fv(loc("physicalToClip"),      1, GL_FALSE, physicalToClip);
+  glUniformMatrix4fv(loc("vrViewInverse"),       1, GL_FALSE, vrViewInverse);
+  glUniformMatrix4fv(loc("envDepthViewInverse"),  1, GL_FALSE, envDepthViewInverse);
+  glUniformMatrix4fv(loc("envDepthView"),         1, GL_FALSE, envDepthViewMat);
+  glUniform4fv(      loc("envDepthTan"),           1, envDepthTan);
+  glUniform1i(       loc("eye"),                  static_cast<GLint>(eye));
+  glUniform1f(       loc("occludedOpacity"),      occludedOpacity);
+  glUniform1f(       loc("sigmaTexels"),          sigmaTexels);
+
+  glBindVertexArray(static_cast<GLuint>(this->VAO));
+  glDrawArrays(GL_TRIANGLES, 0, 3);
+
+  // ------------------------------------------------------------------
+  // Restore GL state.
+  // ------------------------------------------------------------------
+  glBindVertexArray(static_cast<GLuint>(prevVAO));
+  glColorMask(colorMask[0], colorMask[1], colorMask[2], colorMask[3]);
+  glDepthMask(depthMask);
+  glDepthFunc(static_cast<GLenum>(depthFunc));
+  if (!depthTestEnabled)
+  {
+    glDisable(GL_DEPTH_TEST);
+  }
+  glBlendFuncSeparate(static_cast<GLenum>(blendSrcRGB), static_cast<GLenum>(blendDstRGB),
+    static_cast<GLenum>(blendSrcAlpha), static_cast<GLenum>(blendDstAlpha));
+  if (!blendEnabled)
+  {
+    glDisable(GL_BLEND);
+  }
+  glUseProgram(static_cast<GLuint>(prevProgram));
+  // Restore env-depth texture filter settings before unbinding.
+  glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MIN_FILTER, origEnvDepthMinFilter);
+  glTexParameteri(GL_TEXTURE_2D_ARRAY, GL_TEXTURE_MAG_FILTER, origEnvDepthMagFilter);
+  glBindTexture(GL_TEXTURE_2D_ARRAY, static_cast<GLuint>(prevTexBinding));
+  glActiveTexture(static_cast<GLenum>(prevActiveTexUnit));
+}
+
+VTK_ABI_NAMESPACE_END

--- a/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.h
+++ b/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.h
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: Copyright (c) Ken Martin, Will Schroeder, Bill Lorensen
+// SPDX-License-Identifier: BSD-3-Clause
+/**
+ * @class   vtkOpenXREnvironmentDepthOcclusionPrePass
+ * @brief   Depth pre-pass for XR_META_environment_depth real-world occlusion.
+ *
+ * Before each eye's scene render this class runs a fullscreen GLSL pass that
+ * samples the real-world depth texture acquired via xrAcquireEnvironmentDepthImageMETA
+ * and writes corresponding values to gl_FragDepth, with colour writes disabled.
+ *
+ * The subsequent normal VTK scene render uses the default GL_LESS depth test.
+ * Virtual geometry behind a real-world surface therefore fails the depth test
+ * and contributes no colour; those pixels remain alpha = 0, letting the
+ * passthrough camera feed show through.
+ *
+ * This class is only compiled when XR_META_environment_depth is available in
+ * the OpenXR SDK headers.
+ */
+
+#ifndef vtkOpenXREnvironmentDepthOcclusionPrePass_h
+#define vtkOpenXREnvironmentDepthOcclusionPrePass_h
+
+#include "vtkRenderingOpenXRModule.h" // For export macro
+
+// XrEnvironmentDepthImageViewMETA and related types.
+// This header is only included inside an #ifdef XR_META_environment_depth guard
+// in vtkOpenXRRenderWindow.cxx, so XR_META_environment_depth is defined here.
+#include "vtkOpenXRPlatform.h"
+
+#include <cstdint> // uint32_t
+
+VTK_ABI_NAMESPACE_BEGIN
+
+class vtkCamera;
+
+class VTKRENDERINGOPENXR_EXPORT vtkOpenXREnvironmentDepthOcclusionPrePass
+{
+public:
+  vtkOpenXREnvironmentDepthOcclusionPrePass();
+  ~vtkOpenXREnvironmentDepthOcclusionPrePass();
+
+  /**
+   * Apply the depth pre-pass for the given eye.
+   *
+   * Fills the currently-bound FBO's depth buffer with real-world depths so
+   * that virtual geometry behind physical surfaces fails the subsequent
+   * GL_LESS depth test.
+   *
+   * @param eye              0 = left eye, 1 = right eye.
+   * @param camera           The VR eye camera (provides projection/view matrices).
+   * @param envDepthGLTexture GL name of the environment depth GL_TEXTURE_2D_ARRAY.
+   * @param views            Per-eye view poses and FOV from XrEnvironmentDepthImageMETA.
+   */
+  void Apply(uint32_t eye, vtkCamera* camera, uint32_t envDepthGLTexture,
+    const XrEnvironmentDepthImageViewMETA views[2], float physicalScale = 1.0f);
+
+  /**
+   * Render a false-colour depth visualisation overlay for debugging.
+   *
+   * Uses the same reprojection math as Apply() but writes colour pixels
+   * (alpha-blended on top of the scene) instead of depth values.
+   * Pixels that fall outside the env-depth camera frustum are discarded.
+   * Valid depth values are mapped: red = near (0 m), blue = far (5 m).
+   *
+   * Call this AFTER the scene render but BEFORE submitting the eye to the
+   * compositor (i.e. before RenderOneEye / swapchain release).
+   */
+  void DebugVisualize(uint32_t eye, vtkCamera* camera, uint32_t envDepthGLTexture,
+    const XrEnvironmentDepthImageViewMETA views[2]);
+
+  /**
+   * Post-pass for partial real-world occlusion.
+   *
+   * Run AFTER the scene render (and DebugVisualize if desired), BEFORE
+   * submitting the eye to the compositor.
+   *
+   * The env-depth texture is Gaussian-blurred (in its own texel space) before
+   * the depth comparison, smoothing away blockiness caused by the limited
+   * resolution of the depth sensor.  The blurred depth values are then
+   * compared against the scene's depth buffer: pixels where the real-world
+   * surface is closer than the rendered virtual geometry have their alpha
+   * multiplied by @p occludedOpacity:
+   *
+   *   - occludedOpacity = 0.0  → fully occluded  (alpha → 0, invisible)
+   *   - occludedOpacity = 0.5  → half transparent (alpha → alpha * 0.5)
+   *   - (1.0 skips this pass entirely — caller should not call it)
+   *
+   * The currently-bound framebuffer's depth buffer must contain the scene's
+   * rendered depths (i.e. no depth pre-pass should be used when calling this).
+   *
+   * @param sigmaTexels  Gaussian sigma in texels of the env-depth texture.
+   *                     Controls how much the depth image is blurred before
+   *                     comparison. Values in [1, 5] are typical; default 3.
+   */
+  void ApplyOcclusionPostPass(uint32_t eye, vtkCamera* camera, uint32_t envDepthGLTexture,
+    const XrEnvironmentDepthImageViewMETA views[2], float occludedOpacity,
+    float physicalScale = 1.0f, float sigmaTexels = 3.0f);
+
+private:
+  void BuildProgram();
+  void BuildDebugProgram();
+  void BuildOcclusionPostPassProgram();
+
+  uint32_t Program{ 0 };                   // GL program object (same width as GLuint)
+  uint32_t DebugProgram{ 0 };              // GL program for debug visualisation
+  uint32_t OcclusionPostPassProgram{ 0 };  // GL program for partial occlusion post-pass
+  uint32_t VAO{ 0 };                       // Empty VAO for attribute-less fullscreen triangle
+};
+
+VTK_ABI_NAMESPACE_END
+
+#endif // vtkOpenXREnvironmentDepthOcclusionPrePass_h

--- a/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.h
+++ b/Rendering/OpenXR/vtkOpenXREnvironmentDepthOcclusionPrePass.h
@@ -66,7 +66,7 @@ public:
    * compositor (i.e. before RenderOneEye / swapchain release).
    */
   void DebugVisualize(uint32_t eye, vtkCamera* camera, uint32_t envDepthGLTexture,
-    const XrEnvironmentDepthImageViewMETA views[2]);
+    const XrEnvironmentDepthImageViewMETA views[2], float physicalScale = 1.0f);
 
   /**
    * Post-pass for partial real-world occlusion.

--- a/Rendering/OpenXR/vtkOpenXRManager.cxx
+++ b/Rendering/OpenXR/vtkOpenXRManager.cxx
@@ -266,15 +266,18 @@ bool vtkOpenXRManager::StartFBPassthrough()
 void vtkOpenXRManager::StopFBPassthrough()
 {
 #ifdef XR_FB_passthrough
-  if (!this->FBPassthroughActive)
+  // Clean up resources even if passthrough was never successfully started.
+  if (this->FBPassthrough == XR_NULL_HANDLE && this->FBPassthroughLayer == XR_NULL_HANDLE)
   {
+    this->FBPassthroughActive = false;
     return;
   }
 
   xr::ExtensionDispatchTable ext;
   ext.PopulateDispatchTable(this->Instance);
 
-  if (ext.xrPassthroughPauseFB && this->FBPassthrough != XR_NULL_HANDLE)
+  if (this->FBPassthroughActive && ext.xrPassthroughPauseFB &&
+    this->FBPassthrough != XR_NULL_HANDLE)
   {
     ext.xrPassthroughPauseFB(this->FBPassthrough);
   }
@@ -344,12 +347,32 @@ bool vtkOpenXRManager::StartEnvironmentDepth()
 
   // Enumerate swapchain images and store their GL texture IDs.
   uint32_t imageCount = 0;
-  ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(
-    this->EnvDepthSwapchain, 0, &imageCount, nullptr);
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(
+          this->EnvDepthSwapchain, 0, &imageCount, nullptr),
+        "Failed to get environment depth swapchain image count") ||
+    imageCount == 0)
+  {
+    vtkWarningWithObjectMacro(nullptr, "Environment depth swapchain returned zero images.");
+    ext.xrDestroyEnvironmentDepthSwapchainMETA(this->EnvDepthSwapchain);
+    this->EnvDepthSwapchain = XR_NULL_HANDLE;
+    ext.xrDestroyEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+    this->EnvDepthProvider = XR_NULL_HANDLE;
+    return false;
+  }
 
   std::vector<XrSwapchainImageOpenGLKHR> images(imageCount, { XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_KHR });
-  ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(this->EnvDepthSwapchain, imageCount,
-    &imageCount, reinterpret_cast<XrSwapchainImageBaseHeader*>(images.data()));
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(this->EnvDepthSwapchain, imageCount,
+          &imageCount, reinterpret_cast<XrSwapchainImageBaseHeader*>(images.data())),
+        "Failed to enumerate environment depth swapchain images"))
+  {
+    ext.xrDestroyEnvironmentDepthSwapchainMETA(this->EnvDepthSwapchain);
+    this->EnvDepthSwapchain = XR_NULL_HANDLE;
+    ext.xrDestroyEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+    this->EnvDepthProvider = XR_NULL_HANDLE;
+    return false;
+  }
 
   this->EnvDepthTextureIds.resize(imageCount);
   for (uint32_t i = 0; i < imageCount; ++i)
@@ -828,9 +851,17 @@ bool vtkOpenXRManager::EndFrame()
     // Guard against mismatch (prevents xrEndFrame rejection / undefined compositor behavior)
     if (viewCount == 0 || viewCount != this->GetViewCount())
     {
-      //vtkErrorMacro("EndFrame: invalid view count submission");
+      // Still end the frame to keep the frame loop consistent, but avoid
+      // submitting an invalid projection layer.
+      XrFrameEndInfo frameEndInfo{ XR_TYPE_FRAME_END_INFO };
+      frameEndInfo.displayTime = this->CurrentFrame.FrameState.predictedDisplayTime;
+      frameEndInfo.environmentBlendMode = this->EnvironmentBlendMode;
+      frameEndInfo.layerCount = static_cast<uint32_t>(layers.size());
+      frameEndInfo.layers = layers.empty() ? nullptr : layers.data();
+      const bool ok = this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
+        xrEndFrame(this->Session, &frameEndInfo), "xrEndFrame failed");
       this->FrameBegan = false;
-      return false;
+      return ok;
     }
 
     layer.layerFlags = (this->OptionalExtensions.RemotingSupported || this->FBPassthroughActive ||
@@ -1764,11 +1795,11 @@ bool vtkOpenXRManager::CreateOneAction(
     return false;
   }
 
-  // Pose action spaces are intentionally NOT created here.  The Meta Quest
+  // Pose action spaces are intentionally NOT created here. The Meta Quest
   // runtime requires xrAttachSessionActionSets to have been called before
   // xrCreateActionSpace; otherwise xrLocateSpace returns locationFlags=0
   // forever even though the underlying action becomes active and the
-  // interaction profile binds correctly.  The interactor is responsible for
+  // interaction profile binds correctly. The interactor is responsible for
   // calling CreateActionPoseSpaces() on every pose action AFTER
   // AttachSessionActionSets().
 

--- a/Rendering/OpenXR/vtkOpenXRManager.cxx
+++ b/Rendering/OpenXR/vtkOpenXRManager.cxx
@@ -14,6 +14,11 @@
 #include "vtkStringFormatter.h"
 #include "vtkWindows.h" // Does nothing if we are not on windows
 
+// XR_USE_GRAPHICS_API_OPENGL must be defined before vtkOpenXRPlatform.h to
+// obtain XrSwapchainImageOpenGLKHR (needed for environment depth swapchain).
+#define XR_USE_GRAPHICS_API_OPENGL
+#include "vtkOpenXRPlatform.h"
+
 #include <cstring>
 
 #include <iostream>
@@ -193,11 +198,264 @@ bool vtkOpenXRManager::Initialize(vtkOpenXRRenderWindow* xrWindow)
 //------------------------------------------------------------------------------
 void vtkOpenXRManager::Finalize()
 {
+  // Stop environment depth and FB passthrough before destroying the session/instance.
+  this->StopEnvironmentDepth();
+  this->StopFBPassthrough();
   this->DestroyActionSets();
   xrRequestExitSession(this->Session);
   xrEndSession(this->Session);
   xrDestroySession(this->Session);
   xrDestroyInstance(this->Instance);
+}
+
+//------------------------------------------------------------------------------
+bool vtkOpenXRManager::StartFBPassthrough()
+{
+#ifdef XR_FB_passthrough
+  if (!this->OptionalExtensions.FBPassthroughSupported)
+  {
+    vtkWarningWithObjectMacro(nullptr, "XR_FB_passthrough is not supported by this runtime.");
+    return false;
+  }
+
+  xr::ExtensionDispatchTable ext;
+  ext.PopulateDispatchTable(this->Instance);
+
+  if (!ext.xrCreatePassthroughFB)
+  {
+    vtkWarningWithObjectMacro(
+      nullptr, "xrCreatePassthroughFB function pointer could not be loaded.");
+    return false;
+  }
+
+  // Create the passthrough object (requires session in IDLE or later state).
+  XrPassthroughCreateInfoFB passthroughInfo{ XR_TYPE_PASSTHROUGH_CREATE_INFO_FB };
+  passthroughInfo.flags = 0;
+  if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
+        ext.xrCreatePassthroughFB(this->Session, &passthroughInfo, &this->FBPassthrough),
+        "Failed to create XR_FB_passthrough object"))
+  {
+    return false;
+  }
+
+  // Create a full-reconstruction passthrough layer (covers the full view).
+  XrPassthroughLayerCreateInfoFB layerInfo{ XR_TYPE_PASSTHROUGH_LAYER_CREATE_INFO_FB };
+  layerInfo.passthrough = this->FBPassthrough;
+  layerInfo.purpose = XR_PASSTHROUGH_LAYER_PURPOSE_RECONSTRUCTION_FB;
+  layerInfo.flags = XR_PASSTHROUGH_IS_RUNNING_AT_CREATION_BIT_FB;
+  if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
+        ext.xrCreatePassthroughLayerFB(this->Session, &layerInfo, &this->FBPassthroughLayer),
+        "Failed to create XR_FB_passthrough layer"))
+  {
+    ext.xrDestroyPassthroughFB(this->FBPassthrough);
+    this->FBPassthrough = XR_NULL_HANDLE;
+    return false;
+  }
+
+  // Note: xrPassthroughStartFB is called from BeginSession() once the session
+  // is running (XR_SESSION_STATE_READY or later).
+  return true;
+#else
+  vtkWarningWithObjectMacro(
+    nullptr, "XR_FB_passthrough is not available in this OpenXR SDK build.");
+  return false;
+#endif
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXRManager::StopFBPassthrough()
+{
+#ifdef XR_FB_passthrough
+  if (!this->FBPassthroughActive)
+  {
+    return;
+  }
+
+  xr::ExtensionDispatchTable ext;
+  ext.PopulateDispatchTable(this->Instance);
+
+  if (ext.xrPassthroughPauseFB && this->FBPassthrough != XR_NULL_HANDLE)
+  {
+    ext.xrPassthroughPauseFB(this->FBPassthrough);
+  }
+  if (ext.xrDestroyPassthroughLayerFB && this->FBPassthroughLayer != XR_NULL_HANDLE)
+  {
+    ext.xrDestroyPassthroughLayerFB(this->FBPassthroughLayer);
+    this->FBPassthroughLayer = XR_NULL_HANDLE;
+  }
+  if (ext.xrDestroyPassthroughFB && this->FBPassthrough != XR_NULL_HANDLE)
+  {
+    ext.xrDestroyPassthroughFB(this->FBPassthrough);
+    this->FBPassthrough = XR_NULL_HANDLE;
+  }
+
+  this->FBPassthroughActive = false;
+#endif
+}
+
+//------------------------------------------------------------------------------
+bool vtkOpenXRManager::StartEnvironmentDepth()
+{
+#ifdef XR_META_environment_depth
+  if (!this->OptionalExtensions.EnvironmentDepthSupported)
+  {
+    vtkWarningWithObjectMacro(
+      nullptr, "XR_META_environment_depth is not supported by this runtime.");
+    return false;
+  }
+
+  xr::ExtensionDispatchTable ext;
+  ext.PopulateDispatchTable(this->Instance);
+
+  if (!ext.xrCreateEnvironmentDepthProviderMETA)
+  {
+    vtkWarningWithObjectMacro(
+      nullptr, "xrCreateEnvironmentDepthProviderMETA function pointer could not be loaded.");
+    return false;
+  }
+
+  // Create the depth provider.
+  XrEnvironmentDepthProviderCreateInfoMETA providerInfo{
+    XR_TYPE_ENVIRONMENT_DEPTH_PROVIDER_CREATE_INFO_META
+  };
+  providerInfo.createFlags = 0;
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrCreateEnvironmentDepthProviderMETA(
+          this->Session, &providerInfo, &this->EnvDepthProvider),
+        "Failed to create XR_META_environment_depth provider"))
+  {
+    return false;
+  }
+
+  // Create the depth swapchain.
+  XrEnvironmentDepthSwapchainCreateInfoMETA swapchainInfo{
+    XR_TYPE_ENVIRONMENT_DEPTH_SWAPCHAIN_CREATE_INFO_META
+  };
+  swapchainInfo.createFlags = 0;
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrCreateEnvironmentDepthSwapchainMETA(
+          this->EnvDepthProvider, &swapchainInfo, &this->EnvDepthSwapchain),
+        "Failed to create XR_META_environment_depth swapchain"))
+  {
+    ext.xrDestroyEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+    this->EnvDepthProvider = XR_NULL_HANDLE;
+    return false;
+  }
+
+  // Enumerate swapchain images and store their GL texture IDs.
+  uint32_t imageCount = 0;
+  ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(
+    this->EnvDepthSwapchain, 0, &imageCount, nullptr);
+
+  std::vector<XrSwapchainImageOpenGLKHR> images(imageCount, { XR_TYPE_SWAPCHAIN_IMAGE_OPENGL_KHR });
+  ext.xrEnumerateEnvironmentDepthSwapchainImagesMETA(this->EnvDepthSwapchain, imageCount,
+    &imageCount, reinterpret_cast<XrSwapchainImageBaseHeader*>(images.data()));
+
+  this->EnvDepthTextureIds.resize(imageCount);
+  for (uint32_t i = 0; i < imageCount; ++i)
+  {
+    this->EnvDepthTextureIds[i] = images[i].image;
+  }
+
+  // Start the provider — this initiates depth capture.
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrStartEnvironmentDepthProviderMETA(this->EnvDepthProvider),
+        "Failed to start XR_META_environment_depth provider"))
+  {
+    ext.xrDestroyEnvironmentDepthSwapchainMETA(this->EnvDepthSwapchain);
+    this->EnvDepthSwapchain = XR_NULL_HANDLE;
+    ext.xrDestroyEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+    this->EnvDepthProvider = XR_NULL_HANDLE;
+    return false;
+  }
+
+  this->EnvDepthActive = true;
+  vtkDebugWithObjectMacro(
+    nullptr, "Environment depth provider started (" << imageCount << " swapchain images).");
+  return true;
+#else
+  return false;
+#endif
+}
+
+//------------------------------------------------------------------------------
+void vtkOpenXRManager::StopEnvironmentDepth()
+{
+#ifdef XR_META_environment_depth
+  if (!this->EnvDepthActive)
+  {
+    return;
+  }
+
+  xr::ExtensionDispatchTable ext;
+  ext.PopulateDispatchTable(this->Instance);
+
+  if (ext.xrStopEnvironmentDepthProviderMETA && this->EnvDepthProvider != XR_NULL_HANDLE)
+  {
+    ext.xrStopEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+  }
+  if (ext.xrDestroyEnvironmentDepthSwapchainMETA && this->EnvDepthSwapchain != XR_NULL_HANDLE)
+  {
+    ext.xrDestroyEnvironmentDepthSwapchainMETA(this->EnvDepthSwapchain);
+    this->EnvDepthSwapchain = XR_NULL_HANDLE;
+  }
+  if (ext.xrDestroyEnvironmentDepthProviderMETA && this->EnvDepthProvider != XR_NULL_HANDLE)
+  {
+    ext.xrDestroyEnvironmentDepthProviderMETA(this->EnvDepthProvider);
+    this->EnvDepthProvider = XR_NULL_HANDLE;
+  }
+
+  this->EnvDepthTextureIds.clear();
+  this->EnvDepthActive = false;
+#endif
+}
+
+//------------------------------------------------------------------------------
+bool vtkOpenXRManager::AcquireEnvironmentDepthImage()
+{
+#ifdef XR_META_environment_depth
+  xr::ExtensionDispatchTable ext;
+  ext.PopulateDispatchTable(this->Instance);
+
+  if (!ext.xrAcquireEnvironmentDepthImageMETA)
+  {
+    return false;
+  }
+
+  XrEnvironmentDepthImageAcquireInfoMETA acquireInfo{
+    XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_ACQUIRE_INFO_META
+  };
+  acquireInfo.space = this->ReferenceSpace;
+  acquireInfo.displayTime = this->CurrentFrame.FrameState.predictedDisplayTime;
+
+  XrEnvironmentDepthImageMETA depthImage{ XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_META };
+  depthImage.views[0] = { XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META };
+  depthImage.views[1] = { XR_TYPE_ENVIRONMENT_DEPTH_IMAGE_VIEW_META };
+
+  if (!this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+        ext.xrAcquireEnvironmentDepthImageMETA(this->EnvDepthProvider, &acquireInfo, &depthImage),
+        "Failed to acquire environment depth image"))
+  {
+    return false;
+  }
+
+  if (depthImage.swapchainIndex >= this->EnvDepthTextureIds.size())
+  {
+    vtkWarningWithObjectMacro(nullptr,
+      "Environment depth swapchain index " << depthImage.swapchainIndex << " is out of range ("
+                                           << this->EnvDepthTextureIds.size() << " images).");
+    return false;
+  }
+
+  this->EnvDepthTextureId = this->EnvDepthTextureIds[depthImage.swapchainIndex];
+  this->EnvDepthViews[0] = depthImage.views[0];
+  this->EnvDepthViews[1] = depthImage.views[1];
+  this->EnvDepthNearZ = depthImage.nearZ;
+  this->EnvDepthFarZ = depthImage.farZ;
+  return true;
+#else
+  return false;
+#endif
 }
 
 //------------------------------------------------------------------------------
@@ -262,6 +520,26 @@ bool vtkOpenXRManager::BeginSession()
   vtkDebugWithObjectMacro(nullptr, "Session started.");
 
   this->SessionRunning = true;
+
+#ifdef XR_FB_passthrough
+  // Activate FB passthrough now that the session is running.
+  // The XrPassthroughFB and XrPassthroughLayerFB handles were created by
+  // StartFBPassthrough() while the session was still in IDLE state.
+  if (this->FBPassthrough != XR_NULL_HANDLE && !this->FBPassthroughActive)
+  {
+    xr::ExtensionDispatchTable ext;
+    ext.PopulateDispatchTable(this->Instance);
+    if (ext.xrPassthroughStartFB)
+    {
+      if (this->XrCheckOutput(vtkOpenXRManager::WarningOutput,
+            ext.xrPassthroughStartFB(this->FBPassthrough), "Failed to start XR_FB_passthrough"))
+      {
+        this->FBPassthroughActive = true;
+        vtkDebugWithObjectMacro(nullptr, "FB passthrough started.");
+      }
+    }
+  }
+#endif
 
   return true;
 }
@@ -357,6 +635,16 @@ bool vtkOpenXRManager::LocateViews()
     this->CurrentFrame.ShouldRender = false;
   }
 
+#ifdef XR_META_environment_depth
+  if (this->OptionalExtensions.EnvironmentDepthSupported && !this->EnvDepthActive)
+  {
+    this->StartEnvironmentDepth();
+  }
+  if (this->EnvDepthActive)
+  {
+    this->AcquireEnvironmentDepthImage();
+  }
+#endif
   return true;
 }
 
@@ -512,7 +800,24 @@ bool vtkOpenXRManager::EndFrame()
 
   XrCompositionLayerProjection layer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
 
+#ifdef XR_FB_passthrough
+  XrCompositionLayerPassthroughFB passthroughCompositionLayer{
+    XR_TYPE_COMPOSITION_LAYER_PASSTHROUGH_FB
+  };
+#endif
+
   std::vector<XrCompositionLayerBaseHeader*> layers;
+
+#ifdef XR_FB_passthrough
+  if (this->FBPassthroughActive && this->FBPassthroughLayer != XR_NULL_HANDLE)
+  {
+    passthroughCompositionLayer.flags = 0;
+    passthroughCompositionLayer.space = XR_NULL_HANDLE;
+    passthroughCompositionLayer.layerHandle = this->FBPassthroughLayer;
+
+    layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&passthroughCompositionLayer));
+  }
+#endif
 
   // Projection layer
   if (shouldRender)
@@ -528,7 +833,8 @@ bool vtkOpenXRManager::EndFrame()
       return false;
     }
 
-    layer.layerFlags = this->OptionalExtensions.RemotingSupported
+    layer.layerFlags = (this->OptionalExtensions.RemotingSupported || this->FBPassthroughActive ||
+                         this->EnvDepthActive)
       ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT
       : 0;
 
@@ -820,6 +1126,60 @@ std::vector<const char*> vtkOpenXRManager::SelectExtensions(vtkOpenXRRenderWindo
       EnableExtensionIfSupported(XR_MSFT_SCENE_MARKER_EXTENSION_NAME);
   }
 
+  if (window->GetUsePassthrough())
+  {
+    this->OptionalExtensions.FBPassthroughSupported =
+      EnableExtensionIfSupported(XR_FB_PASSTHROUGH_EXTENSION_NAME);
+
+    // If XR_FB_passthrough is available, use OPAQUE blend mode — the camera feed
+    // is composited via a dedicated composition layer in EndFrame().  Only keep the
+    // ALPHA_BLEND preference as a fallback for runtimes that support it but not
+    // XR_FB_passthrough.
+    if (this->OptionalExtensions.FBPassthroughSupported)
+    {
+      this->PreferredEnvironmentBlendMode = XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM;
+    }
+    else
+    {
+      // Log all extensions the runtime offers to aid diagnosis when passthrough
+      // is unavailable (e.g. Meta Quest Link requires the headset to have
+      // developer mode enabled and the Meta XR PC app to grant access).
+      std::string available;
+      for (uint32_t i = 0; i < extensionCount; i++)
+      {
+        if (i > 0)
+        {
+          available += ", ";
+        }
+        available += extensionProperties[i].extensionName;
+      }
+      vtkWarningWithObjectMacro(
+        nullptr, << "XR_FB_passthrough (\"" << XR_FB_PASSTHROUGH_EXTENSION_NAME
+                 << "\") is not in the runtime's extension list. "
+                 << "For Meta Quest Link, ensure developer mode is enabled on the headset "
+                 << "and passthrough access is granted in the Meta XR PC app settings. "
+                 << "Runtime offers " << extensionCount << " extension(s): " << available);
+    }
+
+#ifdef XR_META_environment_depth
+    // Only enable environment depth when real-world depth occlusion will actually be used
+    // (OccludedOpacity < 1.0).  Loading the extension when unused causes
+    // xrAcquireEnvironmentDepthImageMETA to run every frame (via BeginSession ->
+    // StartEnvironmentDepth -> WaitAndBeginFrame -> AcquireEnvironmentDepthImage),
+    // which blocks the render loop and produces position flickering.
+    if (window->GetOccludedOpacity() < 1.0f || window->GetCaptureEnvironmentDepth())
+    {
+      this->OptionalExtensions.EnvironmentDepthSupported =
+        EnableExtensionIfSupported(XR_META_ENVIRONMENT_DEPTH_EXTENSION_NAME);
+      if (!this->OptionalExtensions.EnvironmentDepthSupported)
+      {
+        vtkDebugWithObjectMacro(nullptr,
+          "XR_META_environment_depth is not available; real-world depth occlusion disabled.");
+      }
+    }
+#endif
+  }
+
   this->PrintOptionalExtensions();
 
   return enabledExtensions;
@@ -863,6 +1223,14 @@ void vtkOpenXRManager::PrintOptionalExtensions()
   if (this->OptionalExtensions.SceneMarkerSupported)
   {
     std::cout << "Optional extensions Scene Marker is supported" << std::endl;
+  }
+  if (this->OptionalExtensions.FBPassthroughSupported)
+  {
+    std::cout << "Optional extensions XR_FB_passthrough is supported" << std::endl;
+  }
+  if (this->OptionalExtensions.EnvironmentDepthSupported)
+  {
+    std::cout << "Optional extensions XR_META_environment_depth is supported" << std::endl;
   }
 }
 
@@ -1018,8 +1386,26 @@ bool vtkOpenXRManager::CreateSystemProperties()
         &count, environmentBlendModes.data()),
       "Failed to enumerate environment blend modes");
 
-    // Pick the system's preferred blend mode.
+    // If a preferred blend mode was requested and the runtime supports it, use it.
+    // Otherwise fall back to the runtime's first (most preferred) mode.
     this->EnvironmentBlendMode = environmentBlendModes[0];
+    if (this->PreferredEnvironmentBlendMode != XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM)
+    {
+      for (const XrEnvironmentBlendMode& mode : environmentBlendModes)
+      {
+        if (mode == this->PreferredEnvironmentBlendMode)
+        {
+          this->EnvironmentBlendMode = mode;
+          break;
+        }
+      }
+      if (this->EnvironmentBlendMode != this->PreferredEnvironmentBlendMode)
+      {
+        vtkWarningWithObjectMacro(nullptr,
+          "Requested environment blend mode is not supported by the runtime. "
+          "Falling back to the runtime's preferred blend mode.");
+      }
+    }
   }
 
   this->PrintSupportedViewConfigs();

--- a/Rendering/OpenXR/vtkOpenXRManager.cxx
+++ b/Rendering/OpenXR/vtkOpenXRManager.cxx
@@ -269,23 +269,28 @@ bool vtkOpenXRManager::BeginSession()
 //------------------------------------------------------------------------------
 bool vtkOpenXRManager::WaitAndBeginFrame()
 {
-  // Proactively reset the flag to avoid any attempted rendering in case
-  // the function exits prematurely.
-  this->ShouldRenderCurrentFrame = false;
+  // If a frame has already been started, skip xrWaitFrame/xrBeginFrame
+  // they must only happen once per frame.
+  if (this->FrameBegan)
+  {
+    return true;
+  }
 
   VTK_CHECK_NULL_XRHANDLE(this->Session, "vtkOpenXRManager::WaitAndBeginFrame, Session");
 
-  // Wait frame
-  XrFrameWaitInfo frameWaitInfo{ XR_TYPE_FRAME_WAIT_INFO };
-  XrFrameState frameState{ XR_TYPE_FRAME_STATE };
+  // Reset per-frame validity flags; FrameState/Views/ViewState are written
+  // below or by LocateViews().
+  this->CurrentFrame.ShouldRender = false;
+  this->CurrentFrame.PoseValid = false;
 
+  XrFrameWaitInfo frameWaitInfo{ XR_TYPE_FRAME_WAIT_INFO };
   if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
-        xrWaitFrame(this->Session, &frameWaitInfo, &frameState), "Failed to wait frame."))
+        xrWaitFrame(this->Session, &frameWaitInfo, &this->CurrentFrame.FrameState),
+        "Failed to wait frame."))
   {
     return false;
   }
 
-  // Begin frame
   XrFrameBeginInfo frameBeginInfo{ XR_TYPE_FRAME_BEGIN_INFO };
   if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
         xrBeginFrame(this->Session, &frameBeginInfo), "Failed to begin frame."))
@@ -293,40 +298,69 @@ bool vtkOpenXRManager::WaitAndBeginFrame()
     return false;
   }
 
-  // Store the value of shouldRender to avoid a render
-  this->ShouldRenderCurrentFrame = frameState.shouldRender;
+  this->CurrentFrame.ShouldRender = this->CurrentFrame.FrameState.shouldRender;
 
-  // Store the value of frame predicted display time that is used in EndFrame
-  this->PredictedDisplayTime = frameState.predictedDisplayTime;
+  this->FrameBegan = true;
+  return true;
+}
 
-  if (this->ShouldRenderCurrentFrame)
+//------------------------------------------------------------------------------
+bool vtkOpenXRManager::LocateViews()
+{
+  if (!this->CurrentFrame.ShouldRender)
   {
-    // Locate the views : this will update view pose and projection fov for each view
-    XrViewLocateInfo viewLocateInfo{ XR_TYPE_VIEW_LOCATE_INFO };
-    viewLocateInfo.viewConfigurationType = this->ViewType;
-    viewLocateInfo.displayTime = frameState.predictedDisplayTime;
-    viewLocateInfo.space = this->ReferenceSpace;
-    const uint32_t viewCount = this->GetViewCount();
-    uint32_t viewCountOutput;
-    if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
-          xrLocateViews(this->Session, &viewLocateInfo, &this->RenderResources->ViewState,
-            viewCount, &viewCountOutput, this->RenderResources->Views.data()),
-          "Failed to locate views !"))
-    {
-      return false;
-    }
+    // No need to locate views if the runtime has already indicated that we
+    // shouldn't render this frame.
+    return true;
+  }
 
-    if (viewCountOutput != viewCount)
-    {
-      vtkWarningWithObjectMacro(nullptr, << "ViewCountOutput (" << viewCountOutput
-                                         << ") is different than ViewCount (" << viewCount
-                                         << ") !");
-    }
+  XrViewLocateInfo viewLocateInfo{ XR_TYPE_VIEW_LOCATE_INFO };
+  viewLocateInfo.viewConfigurationType = this->ViewType;
+  viewLocateInfo.displayTime = this->CurrentFrame.FrameState.predictedDisplayTime;
+  viewLocateInfo.space = this->ReferenceSpace;
+  uint32_t viewCountOutput = 0;
+
+  if (!this->XrCheckOutput(ErrorOutput,
+        xrLocateViews(this->Session, &viewLocateInfo, &this->CurrentFrame.ViewState,
+          (uint32_t)this->CurrentFrame.Views.size(), &viewCountOutput,
+          this->CurrentFrame.Views.data()),
+        "xrLocateViews failed"))
+  {
+    return false;
+  }
+
+  // Validate viewStateFlags. If invalid, fall back to the last known-good
+  // pose so we still submit a coherent projection layer (avoids compositor
+  // crashes / black frames). If we have never seen a valid pose, suppress
+  // rendering for this frame entirely.
+  const XrViewStateFlags requiredFlags =
+    XR_VIEW_STATE_POSITION_VALID_BIT | XR_VIEW_STATE_ORIENTATION_VALID_BIT;
+  const bool nowValid =
+    (this->CurrentFrame.ViewState.viewStateFlags & requiredFlags) == requiredFlags;
+
+  if (nowValid)
+  {
+    this->LastValidViewState = this->CurrentFrame.ViewState;
+    this->LastValidViews = this->CurrentFrame.Views;
+    this->CurrentFrame.PoseValid = true;
+  }
+  else if ((this->LastValidViewState.viewStateFlags & requiredFlags) == requiredFlags)
+  {
+    this->CurrentFrame.ViewState = this->LastValidViewState;
+    this->CurrentFrame.Views = this->LastValidViews;
+    this->CurrentFrame.PoseValid = true;
+  }
+  else
+  {
+    // No valid pose ever - skip submitting any projection layer this frame.
+    this->CurrentFrame.PoseValid = false;
+    this->CurrentFrame.ShouldRender = false;
   }
 
   return true;
 }
 
+//------------------------------------------------------------------------------
 // loads the controller models using an extension if it is present.
 // todo needs to be tied into the models class and
 // the gltf conversion completed right now it is here as an example
@@ -370,6 +404,7 @@ bool vtkOpenXRManager::LoadControllerModels()
     extensions.xrLoadControllerModelMSFT(this->Session, controllerModelKeyState.modelKey,
       bufferCapacityInput, &bufferCountOutput, buffer),
     "Failed to get controller model!");
+  delete[] buffer;
 
   return true;
 }
@@ -415,8 +450,8 @@ bool vtkOpenXRManager::PrepareRendering(
   this->GraphicsStrategy->GetColorSwapchainImage(eye, colorSwapchainImageIndex, colorTextureId);
 
   this->RenderResources->ProjectionLayerViews[eye] = { XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW };
-  this->RenderResources->ProjectionLayerViews[eye].pose = this->RenderResources->Views[eye].pose;
-  this->RenderResources->ProjectionLayerViews[eye].fov = this->RenderResources->Views[eye].fov;
+  this->RenderResources->ProjectionLayerViews[eye].pose = this->CurrentFrame.Views[eye].pose;
+  this->RenderResources->ProjectionLayerViews[eye].fov = this->CurrentFrame.Views[eye].fov;
   this->RenderResources->ProjectionLayerViews[eye].subImage.swapchain = colorSwapchain.Swapchain;
   this->RenderResources->ProjectionLayerViews[eye].subImage.imageRect = imageRect;
   this->RenderResources->ProjectionLayerViews[eye].subImage.imageArrayIndex = 0;
@@ -472,40 +507,52 @@ void vtkOpenXRManager::ReleaseSwapchainImage(uint32_t eye)
 //------------------------------------------------------------------------------
 bool vtkOpenXRManager::EndFrame()
 {
-  // The projection layer consists of projection layer views.
+  // Snapshot the render flag from CurrentFrame.
+  const bool shouldRender = this->CurrentFrame.ShouldRender;
+
   XrCompositionLayerProjection layer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
+
   std::vector<XrCompositionLayerBaseHeader*> layers;
 
-  // If the frame has been rendered, then we must submit the ProjectionLayerViews:
-  if (this->ShouldRenderCurrentFrame)
+  // Projection layer
+  if (shouldRender)
   {
-    // Inform the runtime that the app's submitted alpha channel has valid data for use during
-    // composition. The primary display on HoloLens has an additive environment blend mode. It will
-    // ignore the alpha channel. However, mixed reality capture uses the alpha channel if this bit
-    // is set to blend content with the environment.
+    const uint32_t viewCount =
+      static_cast<uint32_t>(this->RenderResources->ProjectionLayerViews.size());
+
+    // Guard against mismatch (prevents xrEndFrame rejection / undefined compositor behavior)
+    if (viewCount == 0 || viewCount != this->GetViewCount())
+    {
+      //vtkErrorMacro("EndFrame: invalid view count submission");
+      this->FrameBegan = false;
+      return false;
+    }
+
     layer.layerFlags = this->OptionalExtensions.RemotingSupported
       ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT
       : 0;
+
     layer.space = this->ReferenceSpace;
-    layer.viewCount = (uint32_t)this->RenderResources->ProjectionLayerViews.size();
+    layer.viewCount = viewCount;
     layer.views = this->RenderResources->ProjectionLayerViews.data();
 
-    // Add the layer to the submitted layers
     layers.push_back(reinterpret_cast<XrCompositionLayerBaseHeader*>(&layer));
   }
-  // Reset should render state
-  this->ShouldRenderCurrentFrame = false;
 
-  // Submit the composition layers for the predicted display time.
-  // If the frame shouldn't be rendered, submit an empty vector
   XrFrameEndInfo frameEndInfo{ XR_TYPE_FRAME_END_INFO };
-  frameEndInfo.displayTime = this->PredictedDisplayTime;
+  frameEndInfo.displayTime = this->CurrentFrame.FrameState.predictedDisplayTime;
   frameEndInfo.environmentBlendMode = this->EnvironmentBlendMode;
-  frameEndInfo.layerCount = (uint32_t)layers.size();
-  frameEndInfo.layers = layers.data();
-  xrEndFrame(this->Session, &frameEndInfo);
+  frameEndInfo.layerCount = static_cast<uint32_t>(layers.size());
+  frameEndInfo.layers = layers.empty() ? nullptr : layers.data();
 
-  return true;
+  // End frame (must always be called if BeginFrame succeeded)
+  const bool ok = this->XrCheckOutput(
+    vtkOpenXRManager::ErrorOutput, xrEndFrame(this->Session, &frameEndInfo), "xrEndFrame failed");
+
+  // Always reset frame state even on failure (prevents deadlock of frame loop)
+  this->FrameBegan = false;
+
+  return ok;
 }
 
 //------------------------------------------------------------------------------
@@ -971,7 +1018,7 @@ bool vtkOpenXRManager::CreateSystemProperties()
         &count, environmentBlendModes.data()),
       "Failed to enumerate environment blend modes");
 
-    // Pick the system's preferred one
+    // Pick the system's preferred blend mode.
     this->EnvironmentBlendMode = environmentBlendModes[0];
   }
 
@@ -1149,7 +1196,7 @@ bool vtkOpenXRManager::CreateSwapchains()
   }
 
   // Preallocate view buffers for xrLocateViews later inside frame loop.
-  this->RenderResources->Views.resize(viewCount, { XR_TYPE_VIEW });
+  this->CurrentFrame.Views.resize(viewCount, { XR_TYPE_VIEW });
 
   // Preallocate projection layer views and depth if needed
   this->RenderResources->ProjectionLayerViews.resize(viewCount);
@@ -1331,25 +1378,39 @@ bool vtkOpenXRManager::CreateOneAction(
     return false;
   }
 
-  // If this is a pose action, we need to create an action space
-  // In order to use LocateSpace
-  if (actionT.ActionType == XR_ACTION_TYPE_POSE_INPUT)
+  // Pose action spaces are intentionally NOT created here.  The Meta Quest
+  // runtime requires xrAttachSessionActionSets to have been called before
+  // xrCreateActionSpace; otherwise xrLocateSpace returns locationFlags=0
+  // forever even though the underlying action becomes active and the
+  // interaction profile binds correctly.  The interactor is responsible for
+  // calling CreateActionPoseSpaces() on every pose action AFTER
+  // AttachSessionActionSets().
+
+  return true;
+}
+
+//------------------------------------------------------------------------------
+bool vtkOpenXRManager::CreateActionPoseSpaces(Action_t& actionT)
+{
+  if (actionT.ActionType != XR_ACTION_TYPE_POSE_INPUT)
   {
-    // One action space per pointer pose and store it in subaction space
-    for (uint32_t hand :
-      { vtkOpenXRManager::ControllerIndex::Left, vtkOpenXRManager::ControllerIndex::Right })
+    return true;
+  }
+  VTK_CHECK_NULL_XRHANDLE(this->Session, "vtkOpenXRManager::CreateActionPoseSpaces, Session");
+  VTK_CHECK_NULL_XRHANDLE(actionT.Action, "vtkOpenXRManager::CreateActionPoseSpaces, Action");
+
+  for (uint32_t hand :
+    { vtkOpenXRManager::ControllerIndex::Left, vtkOpenXRManager::ControllerIndex::Right })
+  {
+    if (!this->CreateOneActionSpace(actionT.Action, this->SubactionPaths[hand],
+          vtkOpenXRUtilities::GetIdentityPose(), actionT.PoseSpaces[hand]))
     {
-      if (!this->CreateOneActionSpace(actionT.Action, this->SubactionPaths[hand],
-            vtkOpenXRUtilities::GetIdentityPose(), actionT.PoseSpaces[hand]))
-      {
-        vtkErrorWithObjectMacro(nullptr,
-          << "Failed to create pose action space for "
-          << (hand == vtkOpenXRManager::ControllerIndex::Left ? "left" : "right") << " hand");
-        return false;
-      };
+      vtkErrorWithObjectMacro(nullptr,
+        << "Failed to create pose action space for "
+        << (hand == vtkOpenXRManager::ControllerIndex::Left ? "left" : "right") << " hand");
+      return false;
     }
   }
-
   return true;
 }
 
@@ -1476,7 +1537,13 @@ bool vtkOpenXRManager::UpdateActionData(Action_t& action_t, const int hand)
         return false;
       }
 
-      if (action_t.States[hand]._pose.isActive)
+      // Always locate the space to get fresh locationFlags, regardless of isActive.
+      // When isActive is false the pose may be unreliable, but the locationFlags
+      // returned by xrLocateSpace will reflect that (bits will not be set), so
+      // callers that check locationFlags before using the pose are safe.
+      // Gating xrLocateSpace on isActive left locationFlags stale (or zero at
+      // startup), causing valid-pose checks downstream to fail even when the
+      // runtime could still supply a usable pose.
       {
         action_t.PoseLocations[hand].type = XR_TYPE_SPACE_LOCATION;
         action_t.PoseLocations[hand].next = nullptr;
@@ -1491,7 +1558,7 @@ bool vtkOpenXRManager::UpdateActionData(Action_t& action_t, const int hand)
         // Store the position of the hand
         if (!this->XrCheckOutput(vtkOpenXRManager::ErrorOutput,
               xrLocateSpace(action_t.PoseSpaces[hand], this->ReferenceSpace,
-                this->PredictedDisplayTime, &action_t.PoseLocations[hand]),
+                this->CurrentFrame.FrameState.predictedDisplayTime, &action_t.PoseLocations[hand]),
               "Failed to locate hand space"))
         {
           return false;
@@ -1538,4 +1605,5 @@ bool vtkOpenXRManager::ApplyVibration(const Action_t& actionT, const int hand,
   }
   return true;
 }
+
 VTK_ABI_NAMESPACE_END

--- a/Rendering/OpenXR/vtkOpenXRManager.h
+++ b/Rendering/OpenXR/vtkOpenXRManager.h
@@ -46,6 +46,20 @@ public:
   }
   ///@}
 
+  struct vtkOpenXRFrameContext
+  {
+    XrFrameState FrameState{ XR_TYPE_FRAME_STATE };
+
+    bool ShouldRender{ false };
+
+    XrViewState ViewState{ XR_TYPE_VIEW_STATE };
+    std::vector<XrView> Views;
+
+    bool PoseValid{ false };
+
+    XrFrameEndInfo EndInfo{ XR_TYPE_FRAME_END_INFO };
+  };
+
   enum OutputLevel
   {
     DebugOutput = 0,
@@ -151,7 +165,7 @@ public:
     {
       return nullptr;
     }
-    return &(this->RenderResources->Views[eye].pose);
+    return &(this->CurrentFrame.Views[eye].pose);
   }
   ///@}
 
@@ -167,7 +181,7 @@ public:
     {
       return nullptr;
     }
-    return &(this->RenderResources->Views[eye].fov);
+    return &(this->CurrentFrame.Views[eye].fov);
   }
   ///@}
 
@@ -196,7 +210,7 @@ public:
    * This value is updated each time we call WaitAndBeginFrame and
    * EndFrame.
    */
-  bool GetShouldRenderCurrentFrame() { return this->ShouldRenderCurrentFrame; }
+  bool GetShouldRenderCurrentFrame() { return this->CurrentFrame.ShouldRender; }
   ///@}
 
   ///@{
@@ -236,6 +250,27 @@ public:
    * eye / display
    */
   bool WaitAndBeginFrame();
+  ///@}
+
+  ///@{
+  /**/
+  bool LocateViews();
+  ///@}
+
+  ///@{
+  /**
+   * Accessors for the current frame's state. CurrentFrame is the single source
+   * of truth for per-frame data (timing, view pose/projection, render flag).
+   * It is established by WaitAndBeginFrame() (timing) and LocateViews() (views,
+   * pose validity), and consumed by EndFrame(). Callers outside the frame
+   * loop should treat returned values as a snapshot of the most recent frame.
+   */
+  const vtkOpenXRFrameContext& GetCurrentFrame() const { return this->CurrentFrame; }
+  XrTime GetPredictedDisplayTime() const { return this->CurrentFrame.FrameState.predictedDisplayTime; }
+  bool GetShouldRender() const { return this->CurrentFrame.ShouldRender; }
+  bool GetPoseValid() const { return this->CurrentFrame.PoseValid; }
+  const XrViewState& GetViewState() const { return this->CurrentFrame.ViewState; }
+  const std::vector<XrView>& GetViews() const { return this->CurrentFrame.Views; }
   ///@}
 
   ///@{
@@ -316,9 +351,24 @@ public:
    * Creates one action with name \p name and localizedName \p localizedName
    * and store the action handle inside \p actionT using the selected
    * active action set.
+   *
+   * For pose actions the per-hand XrSpace must be created separately via
+   * CreateActionPoseSpaces() AFTER AttachSessionActionSets() has been called.
+   * Some runtimes (Meta Quest) return a non-trackable space if xrCreateActionSpace
+   * is invoked before the parent action set has been attached to the session.
    */
   bool CreateOneAction(
     Action_t& actionT, const std::string& name, const std::string& localizedName);
+  ///@}
+
+  ///@{
+  /**
+   * Create the per-hand XrSpace for a pose action. Must be called AFTER
+   * AttachSessionActionSets(); calling it earlier yields spaces that
+   * xrLocateSpace will report as not located on Meta Quest. No-op for
+   * non-pose actions.
+   */
+  bool CreateActionPoseSpaces(Action_t& actionT);
   ///@}
 
   ///@{
@@ -416,13 +466,6 @@ public:
    * Return XrSpace associated with the XrSession
    */
   XrSpace GetReferenceSpace() const { return this->ReferenceSpace; }
-
-  /**
-   * Return runtime predicted display time for next frame.
-   * This may be needed for some OpenXR API calls that requires time information.
-   * This is updated by `WaitAndBeginFrame()`
-   */
-  XrTime GetPredictedDisplayTime() const { return this->PredictedDisplayTime; }
 
 protected:
   vtkOpenXRManager();
@@ -612,9 +655,6 @@ protected:
    */
   struct RenderResources_t
   {
-    XrViewState ViewState{ XR_TYPE_VIEW_STATE };
-    // Each physical Display/Eye is described by a view
-    std::vector<XrView> Views;
     // One configuration view per view : this store
     std::vector<XrViewConfigurationView> ConfigViews;
 
@@ -633,22 +673,30 @@ protected:
   std::vector<XrActionSet> ActionSets;
   XrActionSet* ActiveActionSet = nullptr;
 
-  /**
-   * Store the frame predicted display time in WaitAndBeginFrame
-   * To get the action data at this time and to submit it in EndFrame
-   */
-  XrTime PredictedDisplayTime;
+  // Single source of truth for per-frame state. Established by
+  // WaitAndBeginFrame()/LocateViews(), consumed by EndFrame() and
+  // UpdateActionData(). Public getters expose specific fields.
+  vtkOpenXRFrameContext CurrentFrame;
 
   bool SessionRunning = false;
-  // Following each WaitAndBeginFrame operation, the OpenXR runtime may indicate
-  // whether the current frame should be rendered using the `XrFrameState.shouldRender`
-  // property. We store this information to optimize rendering and prevent unnecessary
-  // render calls. For further details, refer to:
-  // https://registry.khronos.org/OpenXR/specs/1.0/man/html/XrFrameState.html
-  bool ShouldRenderCurrentFrame = false;
+  // Set to true by WaitAndBeginFrame() and reset by EndFrame().
+  // Prevents double-calling xrWaitFrame/xrBeginFrame when
+  // WaitAndBeginFrame() is invoked before PollXrActions() (to get
+  // correct PredictedDisplayTime) and then again inside Render().
+  bool FrameBegan = false;
   // If true, the function UpdateActionData will store
   // pose velocities for pose actions
   bool StorePoseVelocities = false;
+
+  // Last view state and views for which the position and orientation valid bits
+  // were set. Used to fall back to a known-good pose when xrLocateViews returns
+  // invalid flags (e.g. during startup warm-up or brief tracking loss), so that
+  // we always submit a valid projection layer and avoid a black screen on
+  // passthrough headsets that use XR_ENVIRONMENT_BLEND_MODE_OPAQUE.
+  // viewStateFlags is zero-initialized, so the cache is considered empty until
+  // a valid frame has been received.
+  XrViewState LastValidViewState{ XR_TYPE_VIEW_STATE };
+  std::vector<XrView> LastValidViews;
 
   vtkSmartPointer<vtkOpenXRManagerGraphics> GraphicsStrategy;
 

--- a/Rendering/OpenXR/vtkOpenXRManager.h
+++ b/Rendering/OpenXR/vtkOpenXRManager.h
@@ -226,8 +226,11 @@ public:
   bool IsFBPassthroughActive() { return this->FBPassthroughActive; }
 
   /**
-   * Start Meta XR_FB_passthrough.  Creates the passthrough object and layer,
-   * sets FBPassthroughActive on success.  Must be called after Initialize().
+   * Start Meta XR_FB_passthrough.
+   *
+   * Creates the passthrough object and layer. FBPassthroughActive becomes true
+   * only after xrPassthroughStartFB succeeds (triggered from BeginSession()).
+   * Must be called after Initialize().
    * A passthrough composition layer will be prepended in every EndFrame() call
    * while active, so that the camera feed appears as the background.
    */
@@ -335,7 +338,10 @@ public:
    * loop should treat returned values as a snapshot of the most recent frame.
    */
   const vtkOpenXRFrameContext& GetCurrentFrame() const { return this->CurrentFrame; }
-  XrTime GetPredictedDisplayTime() const { return this->CurrentFrame.FrameState.predictedDisplayTime; }
+  XrTime GetPredictedDisplayTime() const
+  {
+    return this->CurrentFrame.FrameState.predictedDisplayTime;
+  }
   bool GetShouldRender() const { return this->CurrentFrame.ShouldRender; }
   bool GetPoseValid() const { return this->CurrentFrame.PoseValid; }
   const XrViewState& GetViewState() const { return this->CurrentFrame.ViewState; }
@@ -559,10 +565,7 @@ public:
   {
     return this->PreferredEnvironmentBlendMode;
   }
-  XrEnvironmentBlendMode GetEnvironmentBlendMode() const
-  {
-    return this->EnvironmentBlendMode;
-  }
+  XrEnvironmentBlendMode GetEnvironmentBlendMode() const { return this->EnvironmentBlendMode; }
   ///@}
 
 protected:

--- a/Rendering/OpenXR/vtkOpenXRManager.h
+++ b/Rendering/OpenXR/vtkOpenXRManager.h
@@ -213,6 +213,75 @@ public:
   bool GetShouldRenderCurrentFrame() { return this->CurrentFrame.ShouldRender; }
   ///@}
 
+  /**
+   * Return true if the XR_FB_passthrough extension is supported and was requested.
+   *
+   * This value is defined by `vtkOpenXRManager::Initialize`.
+   */
+  bool IsFBPassthroughSupported() { return this->OptionalExtensions.FBPassthroughSupported; }
+
+  /**
+   * Return true if FB passthrough is currently active (started successfully).
+   */
+  bool IsFBPassthroughActive() { return this->FBPassthroughActive; }
+
+  /**
+   * Start Meta XR_FB_passthrough.  Creates the passthrough object and layer,
+   * sets FBPassthroughActive on success.  Must be called after Initialize().
+   * A passthrough composition layer will be prepended in every EndFrame() call
+   * while active, so that the camera feed appears as the background.
+   */
+  bool StartFBPassthrough();
+
+  /**
+   * Stop Meta XR_FB_passthrough and release its resources.
+   * Safe to call even if passthrough was never started.
+   */
+  void StopFBPassthrough();
+
+  /**
+   * Return true if the XR_META_environment_depth extension is supported and was requested.
+   */
+  bool IsEnvironmentDepthSupported() { return this->OptionalExtensions.EnvironmentDepthSupported; }
+
+  /**
+   * Return true if environment depth is currently active (provider started successfully).
+   */
+  bool IsEnvironmentDepthActive() { return this->EnvDepthActive; }
+
+  /**
+   * Start the META environment depth provider and swapchain.
+   * Call from BeginSession() once the session is running.
+   */
+  bool StartEnvironmentDepth();
+
+  /**
+   * Stop the META environment depth provider and release its resources.
+   * Safe to call even if environment depth was never started.
+   */
+  void StopEnvironmentDepth();
+
+  /**
+   * Acquire the current frame's environment depth image.
+   * Must be called each frame from WaitAndBeginFrame() while active.
+   * Stores the result (GL texture ID + per-eye views) for use by the pre-pass.
+   */
+  bool AcquireEnvironmentDepthImage();
+
+  /**
+   * Return the GL texture ID of the current frame's environment depth image,
+   * and the per-eye view info (pose + FOV).
+   * Both are valid only after a successful AcquireEnvironmentDepthImage() call.
+   * These accessors are only available when XR_META_environment_depth is defined
+   * by the OpenXR SDK headers (SDK >= 1.1.36).
+   */
+#ifdef XR_META_environment_depth
+  uint32_t GetEnvDepthTextureId() const { return this->EnvDepthTextureId; }
+  const XrEnvironmentDepthImageViewMETA* GetEnvDepthViews() const { return this->EnvDepthViews; }
+  vtkGetMacro(EnvDepthNearZ, float);
+  vtkGetMacro(EnvDepthFarZ, float);
+#endif
+
   ///@{
   /**
    * Start the OpenXR session.
@@ -467,6 +536,35 @@ public:
    */
   XrSpace GetReferenceSpace() const { return this->ReferenceSpace; }
 
+  ///@{
+  /**
+   * Set/Get the preferred environment blend mode.
+   *
+   * When set before initialization, `CreateSystemProperties` will select this
+   * blend mode if the runtime supports it.  If the runtime does not support the
+   * requested mode the first (runtime-preferred) mode is used instead.
+   *
+   * Set to XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM (the default) to use the
+   * runtime's own preference (i.e. the first mode in the enumerated list).
+   *
+   * The value is meaningful only after `Initialize()` has been called.
+   * Call `GetEnvironmentBlendMode()` to retrieve the mode that was actually
+   * selected by the runtime.
+   */
+  void SetPreferredEnvironmentBlendMode(XrEnvironmentBlendMode mode)
+  {
+    this->PreferredEnvironmentBlendMode = mode;
+  }
+  XrEnvironmentBlendMode GetPreferredEnvironmentBlendMode() const
+  {
+    return this->PreferredEnvironmentBlendMode;
+  }
+  XrEnvironmentBlendMode GetEnvironmentBlendMode() const
+  {
+    return this->EnvironmentBlendMode;
+  }
+  ///@}
+
 protected:
   vtkOpenXRManager();
   ~vtkOpenXRManager() = default;
@@ -612,6 +710,10 @@ protected:
   // choose XR_ENVIRONMENT_BLEND_MODE_ADDITIVE or XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND
   XrEnvironmentBlendMode EnvironmentBlendMode;
 
+  // Caller-requested preferred blend mode. XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM means
+  // "use the runtime's preference" (i.e. pick environmentBlendModes[0]).
+  XrEnvironmentBlendMode PreferredEnvironmentBlendMode{ XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM };
+
   // Non optional extension
   bool RenderingBackendExtensionSupported = false;
 
@@ -631,6 +733,8 @@ protected:
     bool RemotingSupported{ false };
     bool SceneUnderstandingSupported{ false };
     bool SceneMarkerSupported{ false };
+    bool FBPassthroughSupported{ false };
+    bool EnvironmentDepthSupported{ false };
   } OptionalExtensions;
   ///@}
 
@@ -701,6 +805,25 @@ protected:
   vtkSmartPointer<vtkOpenXRManagerGraphics> GraphicsStrategy;
 
   vtkSmartPointer<vtkOpenXRManagerConnection> ConnectionStrategy;
+
+  // XR_FB_passthrough handles (valid only when FBPassthroughActive is true)
+#ifdef XR_FB_passthrough
+  XrPassthroughFB FBPassthrough{ XR_NULL_HANDLE };
+  XrPassthroughLayerFB FBPassthroughLayer{ XR_NULL_HANDLE };
+#endif
+  bool FBPassthroughActive{ false };
+
+  // XR_META_environment_depth handles and per-frame state
+#ifdef XR_META_environment_depth
+  XrEnvironmentDepthProviderMETA EnvDepthProvider{ XR_NULL_HANDLE };
+  XrEnvironmentDepthSwapchainMETA EnvDepthSwapchain{ XR_NULL_HANDLE };
+  std::vector<uint32_t> EnvDepthTextureIds; // GL texture IDs, one per swapchain image
+  XrEnvironmentDepthImageViewMETA EnvDepthViews[2];
+  uint32_t EnvDepthTextureId{ 0 };
+  float EnvDepthNearZ{ 0.0 };
+  float EnvDepthFarZ{ 0.0 };
+#endif
+  bool EnvDepthActive{ false };
 
 private:
   vtkOpenXRManager(const vtkOpenXRManager&) = delete;

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
@@ -432,8 +432,8 @@ void vtkOpenXRRenderWindow::StereoMidpoint()
       // Debug visualisation overlay (shown only when explicitly enabled).
       if (this->ShowEnvDepthDebugVisualization)
       {
-        this->EnvDepthPrePass->DebugVisualize(
-          LEFT_EYE, cam, xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews());
+        this->EnvDepthPrePass->DebugVisualize(LEFT_EYE, cam, xrManager.GetEnvDepthTextureId(),
+          xrManager.GetEnvDepthViews(), static_cast<float>(this->GetPhysicalScale()));
       }
       // Post-pass: alpha-based occlusion uses the scene's depth buffer,
       // so it runs AFTER the scene render and BEFORE blitting the eye.
@@ -469,8 +469,8 @@ void vtkOpenXRRenderWindow::StereoRenderComplete()
       // Debug visualisation overlay.
       if (this->ShowEnvDepthDebugVisualization)
       {
-        this->EnvDepthPrePass->DebugVisualize(
-          RIGHT_EYE, cam, xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews());
+        this->EnvDepthPrePass->DebugVisualize(RIGHT_EYE, cam, xrManager.GetEnvDepthTextureId(),
+          xrManager.GetEnvDepthViews(), static_cast<float>(this->GetPhysicalScale()));
       }
       // Post-pass for the right eye.
       if (this->OccludedOpacity < 1.0f)

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
@@ -24,6 +24,10 @@
 
 #include <map> // map
 
+#ifdef XR_META_environment_depth
+#include "vtkOpenXREnvironmentDepthOcclusionPrePass.h"
+#endif
+
 // include what we need for the helper window
 #if defined(_WIN32)
 #include "vtkWin32OpenGLRenderWindow.h"
@@ -235,11 +239,30 @@ void vtkOpenXRRenderWindow::Initialize()
   this->OpenGLInit();
 
   vtkOpenXRManager& xrManager = vtkOpenXRManager::GetInstance();
+  // Always reset the preferred blend mode first so that a previous session's
+  // setting does not carry over into a fresh session.
+  xrManager.SetPreferredEnvironmentBlendMode(XR_ENVIRONMENT_BLEND_MODE_MAX_ENUM);
+  if (this->UsePassthrough)
+  {
+    xrManager.SetPreferredEnvironmentBlendMode(XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND);
+  }
   if (!xrManager.Initialize(this))
   {
     // Set to false because the above init of the HelperWindow sets it to true
     vtkErrorMacro(<< "Failed to initialize OpenXRManager");
     return;
+  }
+
+  // Initialize XR_FB_passthrough objects if passthrough was requested and the
+  // extension is available.  xrPassthroughStartFB will be called from
+  // BeginSession() once the session transitions to the READY state.
+  if (this->UsePassthrough && xrManager.IsFBPassthroughSupported())
+  {
+    if (!xrManager.StartFBPassthrough())
+    {
+      vtkWarningMacro("Failed to initialize XR_FB_passthrough objects. "
+                      "Passthrough will not be available.");
+    }
   }
 
   if (this->EnableSceneUnderstanding && xrManager.IsSceneUnderstandingSupported())
@@ -269,6 +292,16 @@ void vtkOpenXRRenderWindow::Initialize()
 }
 
 //------------------------------------------------------------------------------
+bool vtkOpenXRRenderWindow::IsPassthroughActive() const
+{
+  auto& xrManager = vtkOpenXRManager::GetInstance();
+  // Passthrough is active either via the standard ALPHA_BLEND environment blend
+  // mode, or via the Meta-specific XR_FB_passthrough composition layer.
+  return xrManager.GetEnvironmentBlendMode() == XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND ||
+    xrManager.IsFBPassthroughActive();
+}
+
+//------------------------------------------------------------------------------
 void vtkOpenXRRenderWindow::Finalize()
 {
   if (!this->VRInitialized)
@@ -280,9 +313,16 @@ void vtkOpenXRRenderWindow::Finalize()
   // This must happen before HelperWindow->Finalize() destroys the context.
   this->MakeCurrent();
   this->ReleaseGraphicsResources(this);
+#ifdef XR_META_environment_depth
+  // Destroy the occlusion pre-pass GL programs/VAOs while the context is current.
+  this->EnvDepthPrePass.reset();
+#endif
 
-  // Destroy the GL context before XR teardown to release OpenGL resources
-  // while the context is still valid.
+  // Destroy the GL context before XR teardown. The Meta OpenXR runtime's
+  // XR_FB_passthrough layer deadlocks during xrDestroyInstance when a GL
+  // context is still current. Destroying the context first causes the
+  // runtime to skip its internal GL cleanup (the driver reclaims those
+  // resources anyway) and avoids the hang.
   if (this->HelperWindow && this->HelperWindow->GetGenericContext())
   {
     this->HelperWindow->Finalize();
@@ -358,12 +398,56 @@ void vtkOpenXRRenderWindow::UpdateHMDMatrixPose()
 void vtkOpenXRRenderWindow::StereoUpdate()
 {
   this->Superclass::StereoUpdate();
+
+#ifdef XR_META_environment_depth
+  vtkOpenXRManager& xrManager = vtkOpenXRManager::GetInstance();
+  if (xrManager.IsEnvironmentDepthActive())
+  {
+    // Ensure the post-pass object exists — it handles occlusion post-pass and
+    // debug visualisation. The post-pass runs AFTER each eye's scene render in
+    // StereoMidpoint / StereoRenderComplete, so scene depths are already present
+    // in the depth buffer.  This avoids the timing issue where a pre-pass written
+    // here would be erased by VTK's renderer Clear() before geometry renders.
+    if (!this->EnvDepthPrePass)
+    {
+      this->EnvDepthPrePass = std::make_unique<vtkOpenXREnvironmentDepthOcclusionPrePass>();
+    }
+    // OccludedOpacity < 1.0: ApplyOcclusionPostPass runs after each eye render.
+    // OccludedOpacity == 1.0: depth composition bypassed entirely.
+  }
+#endif
 }
 
 //------------------------------------------------------------------------------
 void vtkOpenXRRenderWindow::StereoMidpoint()
 {
   this->GetState()->vtkglDisable(GL_MULTISAMPLE);
+
+#ifdef XR_META_environment_depth
+  {
+    vtkOpenXRManager& xrManager = vtkOpenXRManager::GetInstance();
+    if (xrManager.IsEnvironmentDepthActive() && this->EnvDepthPrePass)
+    {
+      vtkCamera* cam = this->GetRenderers()->GetFirstRenderer()->GetActiveCamera();
+      // Debug visualisation overlay (shown only when explicitly enabled).
+      if (this->ShowEnvDepthDebugVisualization)
+      {
+        this->EnvDepthPrePass->DebugVisualize(
+          LEFT_EYE, cam, xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews());
+      }
+      // Post-pass: alpha-based occlusion uses the scene's depth buffer,
+      // so it runs AFTER the scene render and BEFORE blitting the eye.
+      // OccludedOpacity=0.0 fully hides occluded pixels (alpha → 0);
+      // OccludedOpacity in (0,1) partially hides them.
+      if (this->OccludedOpacity < 1.0f)
+      {
+        this->EnvDepthPrePass->ApplyOcclusionPostPass(LEFT_EYE, cam,
+          xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews(), this->OccludedOpacity,
+          static_cast<float>(this->GetPhysicalScale()));
+      }
+    }
+  }
+#endif
 
   if (this->SwapBuffers)
   {
@@ -375,6 +459,29 @@ void vtkOpenXRRenderWindow::StereoMidpoint()
 void vtkOpenXRRenderWindow::StereoRenderComplete()
 {
   this->GetState()->vtkglDisable(GL_MULTISAMPLE);
+
+#ifdef XR_META_environment_depth
+  {
+    vtkOpenXRManager& xrManager = vtkOpenXRManager::GetInstance();
+    if (xrManager.IsEnvironmentDepthActive() && this->EnvDepthPrePass)
+    {
+      vtkCamera* cam = this->GetRenderers()->GetFirstRenderer()->GetActiveCamera();
+      // Debug visualisation overlay.
+      if (this->ShowEnvDepthDebugVisualization)
+      {
+        this->EnvDepthPrePass->DebugVisualize(
+          RIGHT_EYE, cam, xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews());
+      }
+      // Post-pass for the right eye.
+      if (this->OccludedOpacity < 1.0f)
+      {
+        this->EnvDepthPrePass->ApplyOcclusionPostPass(RIGHT_EYE, cam,
+          xrManager.GetEnvDepthTextureId(), xrManager.GetEnvDepthViews(), this->OccludedOpacity,
+          static_cast<float>(this->GetPhysicalScale()));
+      }
+    }
+  }
+#endif
 
   if (this->SwapBuffers)
   {

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.cxx
@@ -276,14 +276,19 @@ void vtkOpenXRRenderWindow::Finalize()
     return;
   }
 
+  // Release VTK-owned OpenGL resources while the GL context is still valid.
+  // This must happen before HelperWindow->Finalize() destroys the context.
+  this->MakeCurrent();
+  this->ReleaseGraphicsResources(this);
+
+  // Destroy the GL context before XR teardown to release OpenGL resources
+  // while the context is still valid.
   if (this->HelperWindow && this->HelperWindow->GetGenericContext())
   {
     this->HelperWindow->Finalize();
   }
 
   vtkOpenXRManager::GetInstance().Finalize();
-
-  this->ReleaseGraphicsResources(this);
 
   this->VRInitialized = false;
 }
@@ -292,11 +297,6 @@ void vtkOpenXRRenderWindow::Finalize()
 void vtkOpenXRRenderWindow::Render()
 {
   vtkOpenXRManager& xrManager = vtkOpenXRManager::GetInstance();
-
-  if (!xrManager.WaitAndBeginFrame())
-  {
-    return;
-  }
 
   if (this->Internal->SceneObserver)
   {
@@ -310,8 +310,6 @@ void vtkOpenXRRenderWindow::Render()
     // Start rendering
     this->Superclass::Render();
   }
-
-  xrManager.EndFrame();
 }
 
 //------------------------------------------------------------------------------
@@ -330,6 +328,7 @@ void vtkOpenXRRenderWindow::UpdateHMDMatrixPose()
     vtkErrorMacro(<< "No pose for left eye");
     return;
   }
+
   // Convert a XrPosef to a vtk view matrix
   vtkMatrix4x4* hmdToPhysicalMatrix = this->GetDeviceToPhysicalMatrixForDeviceHandle(handle);
   vtkOpenXRUtilities::SetMatrixFromXrPose(hmdToPhysicalMatrix, *xrPose);

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.h
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.h
@@ -214,8 +214,8 @@ public:
    * If the runtime does not support `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND`
    * the request is silently ignored and VR (opaque) rendering is used.
    *
-   * The renderer background is automatically set to fully transparent when
-   * passthrough is enabled so passthrough is visible.
+   * For passthrough to be visible, the renderer background alpha must be 0
+   * (transparent) so the runtime can blend real-world content behind the scene.
    *
    * Default value: `false`
    */
@@ -229,11 +229,10 @@ public:
    * Set the opacity of virtual geometry that is occluded by real-world surfaces
    * when environment-depth occlusion (`XR_META_environment_depth`) is active.
    *
-   * - 0.0 (default): fully occluded — virtual objects behind real surfaces are
-   *   invisible (hard occlusion using a depth pre-pass).
+   * - 1.0 (default): no occlusion — depth composition is skipped entirely.
    * - 0.0 < value < 1.0: partial occlusion — occluded pixels have their alpha
-   *   multiplied by this value (post-pass, scene renders normally).
-   * - 1.0: no occlusion — depth composition is skipped entirely.
+   *   multiplied by this value (post-pass).
+   * - 0.0: full occlusion — occluded pixels have their alpha set to 0 (post-pass).
    *
    * This must be set before or during rendering; changes take effect on the
    * next rendered frame.

--- a/Rendering/OpenXR/vtkOpenXRRenderWindow.h
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindow.h
@@ -34,10 +34,17 @@
 #include "vtkVRRenderWindow.h"
 
 #include "vtkEventData.h" // for method sig
+#include "vtkOpenXR.h"   // for XR_META_environment_depth and OpenXR types
 
 #include <array>  // array
 #include <memory> // unique_ptr
 #include <string> // string
+
+// Forward declaration for environment depth occlusion pre-pass (used when
+// XR_META_environment_depth is available).
+#ifdef XR_META_environment_depth
+class vtkOpenXREnvironmentDepthOcclusionPrePass;
+#endif
 
 VTK_ABI_NAMESPACE_BEGIN
 
@@ -194,6 +201,98 @@ public:
   vtkGetMacro(EnableSceneUnderstanding, bool);
   ///@}
 
+  ///@{
+  /**
+   * Enable or disable camera passthrough (mixed reality / AR mode).
+   *
+   * When enabled, the OpenXR manager is requested to use
+   * `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND` so that real-world content seen
+   * through the headset's cameras shows through wherever the rendered image
+   * has a transparent (alpha = 0) background.
+   *
+   * This must be set before initializing the render window.
+   * If the runtime does not support `XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND`
+   * the request is silently ignored and VR (opaque) rendering is used.
+   *
+   * The renderer background is automatically set to fully transparent when
+   * passthrough is enabled so passthrough is visible.
+   *
+   * Default value: `false`
+   */
+  vtkSetMacro(UsePassthrough, bool);
+  vtkGetMacro(UsePassthrough, bool);
+  vtkBooleanMacro(UsePassthrough, bool);
+  ///@}
+
+  ///@{
+  /**
+   * Set the opacity of virtual geometry that is occluded by real-world surfaces
+   * when environment-depth occlusion (`XR_META_environment_depth`) is active.
+   *
+   * - 0.0 (default): fully occluded — virtual objects behind real surfaces are
+   *   invisible (hard occlusion using a depth pre-pass).
+   * - 0.0 < value < 1.0: partial occlusion — occluded pixels have their alpha
+   *   multiplied by this value (post-pass, scene renders normally).
+   * - 1.0: no occlusion — depth composition is skipped entirely.
+   *
+   * This must be set before or during rendering; changes take effect on the
+   * next rendered frame.
+   *
+   * Has no effect if `XR_META_environment_depth` is unavailable or inactive.
+   */
+  vtkSetClampMacro(OccludedOpacity, float, 0.0f, 1.0f);
+  vtkGetMacro(OccludedOpacity, float);
+  ///@}
+
+  ///@{
+  /**
+   * Enable or disable the false-colour environment-depth debug visualisation overlay.
+   *
+   * When enabled, a semi-transparent red-to-blue colour map of the real-world
+   * depth texture is composited on top of each eye's rendered frame.
+   * Red = near (0 m), blue = far (~5 m).  Intended for verifying that the
+   * depth texture is being received and reprojected correctly.
+   *
+   * Has no effect if `XR_META_environment_depth` is unavailable or inactive.
+   *
+   * Default value: `false`
+   */
+  vtkSetMacro(ShowEnvDepthDebugVisualization, bool);
+  vtkGetMacro(ShowEnvDepthDebugVisualization, bool);
+  vtkBooleanMacro(ShowEnvDepthDebugVisualization, bool);
+  ///@}
+
+  ///@{
+  /**
+   * When true, the XR_META_environment_depth extension is requested at session
+   * creation time even if OccludedOpacity == 1.0 (i.e. depth-occlusion rendering
+   * is not active).  Use this when you need raw environment-depth data for
+   * purposes other than occlusion (e.g. capturing depth into a volume node).
+   *
+   * Must be set before the OpenXR session is initialized.
+   * Has no effect if the runtime does not support XR_META_environment_depth.
+   *
+   * Default value: `false`
+   */
+  vtkSetMacro(CaptureEnvironmentDepth, bool);
+  vtkGetMacro(CaptureEnvironmentDepth, bool);
+  vtkBooleanMacro(CaptureEnvironmentDepth, bool);
+  ///@}
+
+  /**
+   * Returns true if passthrough (XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND) is
+   * actually active after initialization.
+   *
+   * If UsePassthrough was requested but the runtime does not support
+   * XR_ENVIRONMENT_BLEND_MODE_ALPHA_BLEND, `Initialize()` falls back to the
+   * runtime-preferred mode (typically XR_ENVIRONMENT_BLEND_MODE_OPAQUE) and
+   * this method returns false.
+   *
+   * Only meaningful after Initialize() has been called and returned
+   * VRInitialized == true.
+   */
+  bool IsPassthroughActive() const;
+
   /**
    * Returns scene observer associated with this window.
    *
@@ -233,6 +332,17 @@ private:
 
   bool UseDepthExtension = false;
   bool EnableSceneUnderstanding = false;
+  bool UsePassthrough = false;
+  float OccludedOpacity = 1.0f;
+  bool ShowEnvDepthDebugVisualization = false;
+  bool CaptureEnvironmentDepth = false;
+
+#ifdef XR_META_environment_depth
+  // Depth occlusion pre-pass: writes real-world depths to the depth buffer
+  // before each eye's scene render so virtual geometry behind real surfaces
+  // is naturally occluded. Created on first use, destroyed on ~vtkOpenXRRenderWindow.
+  std::unique_ptr<vtkOpenXREnvironmentDepthOcclusionPrePass> EnvDepthPrePass;
+#endif
 };
 
 VTK_ABI_NAMESPACE_END

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
@@ -55,21 +55,43 @@ void vtkOpenXRRenderWindowInteractor::DoOneEvent(
 {
   this->ProcessXrEvents();
 
-  if (this->Done || !vtkOpenXRManager::GetInstance().IsSessionRunning())
+  vtkOpenXRManager* xrManager = &vtkOpenXRManager::GetInstance();
+  if (this->Done || !xrManager->IsSessionRunning())
   {
     return;
   }
 
+  // Per-frame state is owned by xrManager->CurrentFrame; access via the
+  // GetPredictedDisplayTime / GetShouldRender / GetViews / GetViewState getters.
+  if (!xrManager->WaitAndBeginFrame())
+  {
+    return;
+  }
+
+  // Sync actions before locating views.  The Meta Quest runtime requires
+  // xrSyncActions to have been called before xrLocateViews will return valid
+  // XR_VIEW_STATE_POSITION_VALID_BIT / XR_VIEW_STATE_ORIENTATION_VALID_BIT flags.
+  xrManager->SyncActions();
+
   this->PollXrActions();
+
+  if (!xrManager->LocateViews())
+  {
+    return;
+  }
 
   if (this->RecognizeGestures)
   {
     this->RecognizeComplexGesture(nullptr);
   }
 
-  // Start a render
-  this->InvokeEvent(vtkCommand::RenderEvent);
-  renWin->Render();
+  if (xrManager->GetShouldRender())
+  {
+    this->InvokeEvent(vtkCommand::RenderEvent);
+    renWin->Render();
+  }
+
+  xrManager->EndFrame();
 }
 
 //------------------------------------------------------------------------------
@@ -228,9 +250,6 @@ void vtkOpenXRRenderWindowInteractor::ConvertOpenXRPoseToWorldCoordinates(const 
 //------------------------------------------------------------------------------
 void vtkOpenXRRenderWindowInteractor::PollXrActions()
 {
-  // Update the action states by syncing using the active action set
-  vtkOpenXRManager::GetInstance().SyncActions();
-
   // Iterate over all actions and update their data
   MapAction::iterator it;
   for (it = this->MapActionStruct_Name.begin(); it != this->MapActionStruct_Name.end(); ++it)
@@ -266,28 +285,58 @@ void vtkOpenXRRenderWindowInteractor::PollXrActions()
     XrPosef* handPose = this->GetHandPose(hand);
     if (handPose)
     {
-      this->ConvertOpenXRPoseToWorldCoordinates(*handPose, pos, wxyz, ppos, wdir);
-      auto edHand = vtkEventDataDevice3D::New();
+      ActionData* adHandPose = this->MapActionStruct_Name["handpose"];
+      XrSpaceLocationFlags requiredLocationFlags =
+        XR_SPACE_LOCATION_POSITION_VALID_BIT | XR_SPACE_LOCATION_ORIENTATION_VALID_BIT;
+      bool handPoseValid = (adHandPose->ActionStruct.PoseLocations[hand].locationFlags &
+                             requiredLocationFlags) == requiredLocationFlags;
+
+      vtkNew<vtkEventDataDevice3D> edHand;
       edHand->SetDevice(hand == vtkOpenXRManager::ControllerIndex::Right
           ? vtkEventDataDevice::RightController
           : vtkEventDataDevice::LeftController);
-      edHand->SetWorldPosition(pos);
-      edHand->SetWorldOrientation(wxyz);
-      edHand->SetWorldDirection(wdir);
-      eventDatas[hand].TakeReference(edHand);
-
-      // We should remove this and use event data directly
       int pointerIndex = static_cast<int>(edHand->GetDevice());
-      this->SetPhysicalEventPosition(ppos[0], ppos[1], ppos[2], pointerIndex);
-      this->SetWorldEventPosition(pos[0], pos[1], pos[2], pointerIndex);
-      this->SetWorldEventOrientation(wxyz[0], wxyz[1], wxyz[2], wxyz[3], pointerIndex);
 
-      // Update DeviceToPhysical matrices, this is a read-write access!
-      vtkMatrix4x4* devicePose = renWin->GetDeviceToPhysicalMatrixForDevice(edHand->GetDevice());
-      if (devicePose)
+      if (handPoseValid)
       {
-        vtkOpenXRUtilities::SetMatrixFromXrPose(devicePose, *handPose);
+        // Pose is valid: convert to world coordinates and update all state.
+        this->ConvertOpenXRPoseToWorldCoordinates(*handPose, pos, wxyz, ppos, wdir);
+        edHand->SetWorldPosition(pos);
+        edHand->SetWorldOrientation(wxyz);
+        edHand->SetWorldDirection(wdir);
+
+        // We should remove this and use event data directly
+        this->SetPhysicalEventPosition(ppos[0], ppos[1], ppos[2], pointerIndex);
+        this->SetWorldEventPosition(pos[0], pos[1], pos[2], pointerIndex);
+        this->SetWorldEventOrientation(wxyz[0], wxyz[1], wxyz[2], wxyz[3], pointerIndex);
+
+        // Update DeviceToPhysical matrices, this is a read-write access!
+        vtkMatrix4x4* devicePose = renWin->GetDeviceToPhysicalMatrixForDevice(edHand->GetDevice());
+        if (devicePose)
+        {
+          vtkOpenXRUtilities::SetMatrixFromXrPose(devicePose, *handPose);
+        }
       }
+      else
+      {
+        // Pose is invalid or untracked.  Populate the event data from the
+        // last known-valid world state so that downstream handlers (Dolly3D,
+        // PositionProp, etc.) do not receive garbage coordinates and produce
+        // spurious world movement.  The stored event positions are NOT updated
+        // so they continue to reflect the last valid tracked pose.
+        double* lastPos = this->GetWorldEventPosition(pointerIndex);
+        double* lastOri = this->GetWorldEventOrientation(pointerIndex);
+        if (lastPos)
+        {
+          edHand->SetWorldPosition(lastPos);
+        }
+        if (lastOri)
+        {
+          edHand->SetWorldOrientation(lastOri);
+        }
+      }
+
+      eventDatas[hand] = edHand;
     }
   }
 
@@ -567,6 +616,28 @@ void vtkOpenXRRenderWindowInteractor::Initialize()
   {
     this->Initialized = false;
     return;
+  }
+
+  // Pose action spaces must be created AFTER xrAttachSessionActionSets - see vtkOpenXRManager::CreateOneAction
+  // for the motivation.  Walk the action map and create the per-hand XrSpace for every pose action now that 
+  // the action set is attached.
+  for (auto& actionEntry : this->MapActionStruct_Name)
+  {
+    ActionData* actionData = actionEntry.second;
+    if (actionData == nullptr)
+    {
+      continue;
+    }
+    if (actionData->ActionStruct.ActionType != XR_ACTION_TYPE_POSE_INPUT)
+    {
+      continue;
+    }
+    if (!vtkOpenXRManager::GetInstance().CreateActionPoseSpaces(actionData->ActionStruct))
+    {
+      vtkErrorMacro(<< "Failed to create pose spaces for action " << actionEntry.first);
+      this->Initialized = false;
+      return;
+    }
   }
 }
 

--- a/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
+++ b/Rendering/OpenXR/vtkOpenXRRenderWindowInteractor.cxx
@@ -77,6 +77,7 @@ void vtkOpenXRRenderWindowInteractor::DoOneEvent(
 
   if (!xrManager->LocateViews())
   {
+    xrManager->EndFrame();
     return;
   }
 


### PR DESCRIPTION
### ENH: Add Meta passthrough and environment depth occlusion support

Adds support for `XR_FB_passthrough` and `XR_META_environment_depth` (requires OpenXR SDK 1.1.36).

**New API on `vtkOpenXRRenderWindow`:**
- `UsePassthrough` / `PassthroughOn` / `PassthroughOff` — request mixed reality via standard alpha-blend or Meta-specific composition layer
- `OccludedOpacity [0,1]` — control real-world occlusion strength via depth pre-pass
- `ShowEnvDepthDebugVisualization` — false-colour depth overlay
- `CaptureEnvironmentDepth` — force depth capture even at full opacity
- `IsPassthroughActive()` — query live passthrough state

**New class `vtkOpenXREnvironmentDepthOcclusionPrePass`:** fullscreen-triangle pass that reads the META environment depth swapchain and composites real-world occlusion or a debug overlay onto each eye's frame.

**New API on `vtkOpenXRManager`:** `StartFBPassthrough`, `StopFBPassthrough`, `StartEnvironmentDepth`, `StopEnvironmentDepth`, `AcquireEnvironmentDepthImage`, and related query/accessor methods.

---

### ENH: Streamline frame state management into a single pathway

Consolidates per-frame XR state into a single `vtkOpenXRFrameContext` struct, removing now-redundant standalone members.

**Processing loop fixes:**
- `WaitAndBeginFrame()` called at the start of `DoOneEvent()` so `PredictedDisplayTime` is valid before `PollXrActions()`
- `SyncActions()` moved to just before `LocateViews()` to ensure action data is always synced before poses are located
- `FrameBegan` guard prevents double `xrWaitFrame`/`xrBeginFrame` calls
- `LocateViews()` extracted from `WaitAndBeginFrame()` for clarity

**Other fixes:**
- Guard hand-pose updates with `XR_SPACE_LOCATION_POSITION_VALID_BIT`
- Cache last valid view state and fall back on tracking loss (avoids black frames on startup)
- Defer pose-space creation to `CreateActionPoseSpaces()` after `AttachSessionActionSets()`
- Fix memory leak: missing `delete[]` for controller model buffer